### PR TITLE
Add option mapping with defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ npm install node-jq --save
 ## Usage
 
 ```javascript
-import jq from 'node-jq'
+import { run } from 'node-jq'
 // or
-const jq = require('node-jq')
+const { run } = require('node-jq')
 
 const filter = '. | map(select(.foo > 10))'
 const jsonPath = '/path/to/json'
 
-jq.run(filter, jsonPath, options = {})
+run(filter, jsonPath, options = {})
   .then((output) => {
     // something with the output
   })

--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ const jsonPath = '/path/to/json'
 
 run(filter, jsonPath, options = {})
   .then((output) => {
+    console.log(output)
     // something with the output
   })
   .catch((err) => {
+    console.error(err)
     // something with the error
   })
 ```
@@ -42,7 +44,7 @@ run(filter, jsonPath, options = {})
 | Option   | Type     | Default    | Values                        | Description                |
 |----------|----------|------------|-------------------------------|----------------------------|
 | `input`  | *String* | `'file'`   | `'file', 'json', 'string'`    | Specify the type of input  |
-| `output` | *String* | `'string'` | `'string', 'json', 'compact'` | Specify the type of output |
+| `output` | *String* | `'pretty'` | `'json', 'string', 'pretty'`  | Specify the type of output |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # node-jq
 
-[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/) [![npm release](https://img.shields.io/npm/v/node-jq.svg)](https://www.npmjs.com/package/node-jq)  [![Travis Build](https://img.shields.io/travis/sanack/node-jq/master.svg)](https://travis-ci.org/sanack/node-jq) [![Coverage Status](https://coveralls.io/repos/github/sanack/node-jq/badge.svg?branch=master)](https://coveralls.io/github/sanack/node-jq?branch=master) [![npm downloads](https://img.shields.io/npm/dm/node-jq.svg)](https://www.npmjs.com/package/node-jq) [![Gitter](https://badges.gitter.im/davesnx/node-jq.svg)](https://gitter.im/davesnx/node-jq?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?maxAge=3600)](http://standardjs.com/) [![npm release](https://img.shields.io/npm/v/node-jq.svg?maxAge=3600)](https://www.npmjs.com/package/node-jq)  [![Travis Build](https://img.shields.io/travis/sanack/node-jq/master.svg?maxAge=3600)](https://travis-ci.org/sanack/node-jq) [![Coverage Status](https://coveralls.io/repos/github/sanack/node-jq/badge.svg?branch=master)](https://coveralls.io/github/sanack/node-jq?branch=master) [![npm downloads](https://img.shields.io/npm/dm/node-jq.svg?maxAge=3600)](https://www.npmjs.com/package/node-jq) [![Gitter](https://badges.gitter.im/davesnx/node-jq.svg)](https://gitter.im/davesnx/node-jq?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 [`jq`](https://stedolan.github.io/jq/) is a lightweight and flexible
     command-line JSON processor.
 
-> Work in progress...
+> Work in progress....
+
+## Prerequisites
+
+You will need [`jq`](https://stedolan.github.io/jq/download/) installed before
+you can do anything with this package.
 
 ## Installation
-
-Need to have [`jq`](https://stedolan.github.io/jq/download/) installed.
 
 ```bash
 npm install node-jq --save
@@ -18,14 +21,14 @@ npm install node-jq --save
 ## Usage
 
 ```javascript
-import { run } from 'node-jq'
+import jq from 'node-jq'
 // or
-const run = require('node-jq').run
+const jq = require('node-jq')
 
 const filter = '. | map(select(.foo > 10))'
-const jsonPath = path.join(__dirname, 'path', 'to', 'json')
+const jsonPath = '/path/to/json'
 
-run(filter, jsonPath)
+jq.run(filter, jsonPath, options = {})
   .then((output) => {
     // something with the output
   })
@@ -33,6 +36,13 @@ run(filter, jsonPath)
     // something with the error
   })
 ```
+
+## Options
+
+| Option   | Type     | Default    | Values                        | Description                |
+|----------|----------|------------|-------------------------------|----------------------------|
+| `input`  | *String* | `'file'`   | `'file', 'json', 'string'`    | Specify the type of input  |
+| `output` | *String* | `'string'` | `'string', 'json', 'compact'` | Specify the type of output |
 
 ## License
 

--- a/src/jq.js
+++ b/src/jq.js
@@ -1,6 +1,5 @@
 import execa from 'execa'
-import { validateJsonPath } from './utils'
-import { buildNullInputParams } from './options'
+import { parseOptions } from './options'
 
 const createJqCommand = (filter, json, options = {}) => {
   const command = {
@@ -8,12 +7,7 @@ const createJqCommand = (filter, json, options = {}) => {
     params: []
   }
 
-  if (options.nullInput === true) {
-    command.params = buildNullInputParams(filter, json)
-  } else {
-    validateJsonPath(json)
-    command.params = [filter, json]
-  }
+  command.params = parseOptions(filter, json, options)
 
   return command
 }
@@ -23,7 +17,11 @@ export const run = (filter, json, options = {}) => {
     const { cmd, params } = createJqCommand(filter, json, options)
     execa(cmd, params)
     .then(({ stdout }) => {
-      return resolve(JSON.parse(stdout))
+      if (options.output === 'json') {
+        return resolve(JSON.parse(stdout))
+      } else {
+        return resolve(stdout)
+      }
     })
     .catch(reject)
   })

--- a/src/jq.js
+++ b/src/jq.js
@@ -6,9 +6,7 @@ const createJqCommand = (filter, json, options = {}) => {
     cmd: 'jq',
     params: []
   }
-
   command.params = parseOptions(filter, json, options)
-
   return command
 }
 

--- a/src/options.js
+++ b/src/options.js
@@ -1,8 +1,8 @@
 import { validateJsonPath } from './utils'
 
-const optionDefaults = {
+export const optionDefaults = {
   input: 'file',
-  output: 'string'
+  output: 'pretty'
 }
 
 const optionMap = {
@@ -22,7 +22,7 @@ const optionMap = {
   },
   output: {
     buildParams: (filter, json, params, value) => {
-      if (value === 'compact') {
+      if (value === 'string') {
         params.unshift('--compact-output')
       }
     }

--- a/src/options.js
+++ b/src/options.js
@@ -1,6 +1,51 @@
-export const buildNullInputParams = (filter, json) => {
-  return [
-    '--null-input',
-    `${JSON.stringify(json)} | ${filter}`
-  ]
+import { validateJsonPath } from './utils'
+
+const optionDefaults = {
+  input: 'file',
+  output: 'string'
+}
+
+const optionMap = {
+  input: {
+    buildParams: (filter, json, params, value) => {
+      if (value === 'file') {
+        validateJsonPath(params[params.length - 1])
+      } else {
+        params.pop()
+        params.unshift('--null-input')
+        if (value === 'json') {
+          json = JSON.stringify(json)
+        }
+        params[params.length - 1] = `${json} | ${filter}`
+      }
+    }
+  },
+  compactOutput: {
+    buildParams: (filter, json, params, value) => {
+      if (value === true) {
+        params.unshift('--compact-output')
+      }
+    }
+  }
+}
+
+const mergeOptionDefaults = (options = {}) => {
+  Object.keys(optionDefaults).forEach((key) => {
+    if (options[key] === undefined) {
+      options[key] = optionDefaults[key]
+    }
+  })
+}
+
+export const parseOptions = (filter, json, options = {}) => {
+  mergeOptionDefaults(options)
+  return Object.keys(options).reduce(
+    (params, key, index, array) => {
+      if (optionMap[key] !== undefined) {
+        optionMap[key].buildParams(filter, json, params, options[key])
+      }
+      return params
+    },
+    [filter, json]
+  )
 }

--- a/src/options.js
+++ b/src/options.js
@@ -29,16 +29,8 @@ const optionMap = {
   }
 }
 
-const mergeOptionDefaults = (options = {}) => {
-  Object.keys(optionDefaults).forEach((key) => {
-    if (options[key] === undefined) {
-      options[key] = optionDefaults[key]
-    }
-  })
-}
-
 export const parseOptions = (filter, json, options = {}) => {
-  mergeOptionDefaults(options)
+  options = Object.assign(optionDefaults, options)
   return Object.keys(options).reduce(
     (params, key, index, array) => {
       if (optionMap[key] !== undefined) {

--- a/src/options.js
+++ b/src/options.js
@@ -20,9 +20,9 @@ const optionMap = {
       }
     }
   },
-  compactOutput: {
+  output: {
     buildParams: (filter, json, params, value) => {
-      if (value === true) {
+      if (value === 'compact') {
         params.unshift('--compact-output')
       }
     }

--- a/src/options.js
+++ b/src/options.js
@@ -29,8 +29,16 @@ const optionMap = {
   }
 }
 
+const mergeOptionDefaults = (options = {}) => {
+  Object.keys(optionDefaults).forEach((key) => {
+    if (options[key] === undefined) {
+      options[key] = optionDefaults[key]
+    }
+  })
+}
+
 export const parseOptions = (filter, json, options = {}) => {
-  options = Object.assign(optionDefaults, options)
+  mergeOptionDefaults(options)
   return Object.keys(options).reduce(
     (params, key, index, array) => {
       if (optionMap[key] !== undefined) {

--- a/test/jq.test.js
+++ b/test/jq.test.js
@@ -12,26 +12,25 @@ const asteriskPathFixture = path.join(ROOT_PATH, 'src', '*.js')
 const filter = '. | map(select(.a == .id))'
 
 describe('jq core', () => {
-  it('should return an stdout object', (done) => {
-    run(filter, jsonPathFixture)
-    .then((obj) => {
-      done()
-    })
+  it('should fulfill its promise', () => {
+    return expect(
+      run(filter, jsonPathFixture)
+    ).to.eventually.be.fulfilled
   })
 
-  it('should fail on a non valid filter', () => {
+  it('should fail on an invalid filter', () => {
     return expect(
       run('lola', jsonPathFixture)
     ).to.eventually.be.rejectedWith(Error)
   })
 
-  it('should fail on a non valid path', () => {
+  it('should fail on an invalid path', () => {
     return expect(
       run(filter, asteriskPathFixture)
     ).to.eventually.be.rejectedWith(Error)
   })
 
-  it('should fail on a non valid json', () => {
+  it('should fail on an invalid json', () => {
     return expect(
       run(filter, jsPathFixture)
     ).to.eventually.be.rejectedWith(Error)

--- a/test/jq.test.js
+++ b/test/jq.test.js
@@ -12,10 +12,11 @@ const asteriskPathFixture = path.join(ROOT_PATH, 'src', '*.js')
 const filter = '. | map(select(.a == .id))'
 
 describe('jq core', () => {
-  it('should return a stdout object', () => {
-    return expect(
-      run(filter, jsonPathFixture)
-    ).to.eventually.be.instanceof(Object)
+  it('should return an stdout object', (done) => {
+    run(filter, jsonPathFixture)
+    .then((obj) => {
+      done()
+    })
   })
 
   it('should fail on a non valid filter', () => {

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -1,32 +1,87 @@
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 chai.use(chaiAsPromised)
+import path from 'path'
 
 import { run } from '../src/jq'
+import { optionDefaults } from '../src/options'
 
-import FIXTURE_JSON from './fixtures/1.json'
+const PATH_FIXTURES = path.join(__dirname, 'fixtures')
+const PATH_JSON_FIXTURE = path.join(PATH_FIXTURES, '1.json')
+
+const FIXTURE_JSON = require(PATH_JSON_FIXTURE)
 const FIXTURE_JSON_STRING = JSON.stringify(FIXTURE_JSON)
+const FIXTURE_JSON_PRETTY = JSON.stringify(FIXTURE_JSON, null, 2)
+
+const OPTION_DEFAULTS = {
+  input: 'file',
+  output: 'pretty'
+}
 
 describe('options', () => {
+  describe('defaults', () => {
+    it('should be as expected', () => {
+      return expect(optionDefaults).to.deep.equal(OPTION_DEFAULTS)
+    })
+  })
+
+  describe('input: file', () => {
+    it('should accept a file path as input', () => {
+      return expect(
+        run('.', PATH_JSON_FIXTURE, {
+          input: 'file'
+        })
+      ).to.eventually.be.fulfilled
+    })
+  })
+
   describe('input: json', () => {
-    it('should run the filter inline with --null-input', () => {
+    it('should accept a json object as input', () => {
       return expect(
         run('.', FIXTURE_JSON, {
-          input: 'json',
+          input: 'json'
+        })
+      ).to.eventually.be.fulfilled
+    })
+  })
+
+  describe('input: string', () => {
+    it('should accept a json string as input', () => {
+      return expect(
+        run('.', FIXTURE_JSON_STRING, {
+          input: 'string'
+        })
+      ).to.eventually.be.fulfilled
+    })
+  })
+
+  describe('output: json', () => {
+    it('should return a minified json string', () => {
+      return expect(
+        run('.', PATH_JSON_FIXTURE, {
           output: 'json'
         })
       ).to.eventually.become(FIXTURE_JSON)
     })
   })
 
-  describe('output: compact', () => {
-    it('should run the filter inline with --compact-output', () => {
+  describe('output: string', () => {
+    it('should return a minified json string', () => {
       return expect(
-        run('.', FIXTURE_JSON, {
-          input: 'json',
-          output: 'compact'
+        run('.', PATH_JSON_FIXTURE, {
+          output: 'string'
         })
       ).to.eventually.become(FIXTURE_JSON_STRING)
+    })
+  })
+
+  describe('output: pretty', () => {
+    it('should return a prettified json string', () => {
+      return expect(
+        run('.', PATH_JSON_FIXTURE, {
+          output: 'pretty'
+        })
+      ).to.eventually.become(FIXTURE_JSON_PRETTY)
     })
   })
 })

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -5,6 +5,7 @@ chai.use(chaiAsPromised)
 import { run } from '../src/jq'
 
 import FIXTURE_JSON from './fixtures/1.json'
+const FIXTURE_JSON_STRING = JSON.stringify(FIXTURE_JSON)
 
 describe('options', () => {
   describe('input: json', () => {
@@ -18,14 +19,14 @@ describe('options', () => {
     })
   })
 
-  describe('compactOutput', () => {
+  describe('output: compact', () => {
     it('should run the filter inline with --compact-output', () => {
       return expect(
         run('.', FIXTURE_JSON, {
-          compactOutput: true,
-          input: 'json'
+          input: 'json',
+          output: 'compact'
         })
-      ).to.eventually.become(JSON.stringify(FIXTURE_JSON))
+      ).to.eventually.become(FIXTURE_JSON_STRING)
     })
   })
 })

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -4,14 +4,26 @@ chai.use(chaiAsPromised)
 import { run } from '../src/jq'
 import jsonFixture from './fixtures/1.json'
 
-const jsonFixtureToString = JSON.stringify(jsonFixture)
-
 describe('options', () => {
-  describe('--null-input', () => {
-    it('should run the filter inline with null-input', () => {
+  describe('input: json', () => {
+    it('should run the filter inline with --null-input', () => {
       return expect(
-        run('.', jsonFixtureToString, { nullInput: true })
-      ).to.eventually.become(jsonFixtureToString)
+        run('.', jsonFixture, {
+          input: 'json',
+          output: 'json'
+        })
+      ).to.eventually.become(jsonFixture)
+    })
+  })
+
+  describe('compactOutput', () => {
+    it('should run the filter inline with --compact-output', () => {
+      return expect(
+        run('.', jsonFixture, {
+          compactOutput: true,
+          input: 'json'
+        })
+      ).to.eventually.become(JSON.stringify(jsonFixture))
     })
   })
 })


### PR DESCRIPTION
Proposal for option mapping.

I believe that this way it's easier to distinguish between `file`, `json` and `string` input (defaulting to file input). Output is either `json` or `string`. 

(I thought `nullInput` wasn't descriptive enough)

Todo in this PR:
- [x] Add option documentation to README
- [x] Add more meaningful tests

Optional: Add more options as you see fit ([jq-manual](https://stedolan.github.io/jq/manual/))