### PR TITLE
Improve internal API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "node-jq",
+  "version": "0.0.0-semantic-release",
   "description": "Run jq in node",
   "main": "lib/jq.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "node-jq",
-  "version": "0.0.0-development",
   "description": "Run jq in node",
   "main": "lib/jq.js",
   "repository": {

--- a/src/command.js
+++ b/src/command.js
@@ -1,0 +1,28 @@
+import path from 'path'
+import { parseOptions } from './options'
+
+const JQ_PATH = path.join(__dirname, '../bin/jq')
+
+const escapeArg = (arg) => {
+  arg = arg.toString()
+
+  // Double up all the backslashes and escape the double quote
+  arg = arg.replace(/(\\*)"/g, '$1$1\\"')
+
+  // Escape the backslashes that would escape the double quote that's added
+  // later to the end of the string
+  arg = arg.replace(/(\\*)$/, '$1$1')
+
+  arg = '"' + arg + '"'
+  return arg
+}
+
+const shellEscape = (params) => {
+  return params.reduce((previous, current) => {
+    return previous + ' ' + escapeArg(current)
+  }, '')
+}
+
+export const commandFactory = (filter, json, options = {}) => {
+  return JQ_PATH + shellEscape(parseOptions(filter, json, options))
+}

--- a/src/exec.js
+++ b/src/exec.js
@@ -3,39 +3,19 @@ import stripEof from 'strip-eof'
 
 const TEN_MEBIBYTE = 1024 * 1024 * 10
 
-const exec = (cmd, params) => {
+const exec = (command) => {
   return new Promise((resolve, reject) => {
     childProcess.exec(
-      cmd + buildParams(params),
+      command,
       { maxBuffer: TEN_MEBIBYTE },
       (error, stdout, stderr) => {
         if (error) {
           return reject(Error(stderr))
         }
-        resolve(stripEof(stdout))
+        return resolve(stripEof(stdout))
       }
     )
   })
-}
-
-const escapeArg = (arg) => {
-  arg = arg.toString()
-
-  // Double up all the backslashes and escape the double quote
-  arg = arg.replace(/(\\*)"/g, '$1$1\\"')
-
-  // Escape the backslashes that would escape the double quote that's added
-  // later to the end of the string
-  arg = arg.replace(/(\\*)$/, '$1$1')
-
-  arg = '"' + arg + '"'
-  return arg
-}
-
-const buildParams = (params) => {
-  return params.reduce((previous, current) => {
-    return previous + ' ' + escapeArg(current)
-  }, '')
 }
 
 export default exec

--- a/src/jq.js
+++ b/src/jq.js
@@ -1,27 +1,17 @@
 import exec from './exec'
-import { parseOptions } from './options'
-import path from 'path'
-
-const createJqCommand = (filter, json, options = {}) => {
-  const command = {
-    cmd: path.join(__dirname, '../bin/jq'),
-    params: []
-  }
-  command.params = parseOptions(filter, json, options)
-  return command
-}
+import { commandFactory } from './command'
 
 export const run = (filter, json, options = {}) => {
   return new Promise((resolve, reject) => {
-    const { cmd, params } = createJqCommand(filter, json, options)
-    exec(cmd, params)
-    .then((stdout) => {
-      if (options.output === 'json') {
-        return resolve(JSON.parse(stdout))
-      } else {
-        return resolve(stdout)
-      }
-    })
-    .catch(reject)
+    const command = commandFactory(filter, json, options)
+    exec(command)
+      .then((stdout) => {
+        if (options.output === 'json') {
+          return resolve(JSON.parse(stdout))
+        } else {
+          return resolve(stdout)
+        }
+      })
+      .catch(reject)
   })
 }

--- a/src/options.js
+++ b/src/options.js
@@ -1,4 +1,4 @@
-import { validateJsonPath } from './utils'
+import { validateJSONPath } from './utils'
 
 export const optionDefaults = {
   input: 'file',
@@ -9,7 +9,7 @@ const optionMap = {
   input: {
     buildParams: (filter, json, params, value) => {
       if (value === 'file') {
-        validateJsonPath(params[params.length - 1])
+        validateJSONPath(params[params.length - 1])
       } else {
         params.pop()
         params.unshift('--null-input')

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,29 +1,18 @@
 import isPathValid from 'is-valid-path'
 
 const INVALID_PATH_ERROR = 'Invalid path'
-const INVALID_JSON_PATH_ERROR = 'Not a .json file'
+const INVALID_JSON_PATH_ERROR = 'Not a json file'
 
-export const isAJsonPath = (path) => {
+export const isJSONPath = (path) => {
   return /\.json$/.test(path)
 }
 
-// FIXME: JSON.parse is so slow
-//        we could access the first key of the object
-export const isAJson = (json) => {
-  try {
-    JSON.parse(json)
-  } catch (e) {
-    return false
-  }
-  return true
-}
-
-export const validateJsonPath = (jsonPath) => {
-  if (!isPathValid(jsonPath)) {
+export const validateJSONPath = (JSONFile) => {
+  if (!isPathValid(JSONFile)) {
     throw (Error(INVALID_PATH_ERROR))
   }
 
-  if (!isAJsonPath(jsonPath)) {
+  if (!isJSONPath(JSONFile)) {
     throw (Error(INVALID_JSON_PATH_ERROR))
   }
 }

--- a/test/fixtures/1.js
+++ b/test/fixtures/1.js
@@ -1,6 +1,6 @@
-const shiet = {
-  lola: 'lola',
-  flores: 'flores'
+const json = {
+  foo: 'bar',
+  random: 123
 }
 
-console.log(shiet)
+console.log(json)

--- a/test/jq.test.js
+++ b/test/jq.test.js
@@ -1,6 +1,6 @@
 import chai, { expect } from 'chai'
-import chaiAsPromised from 'chai-as-promised'
-chai.use(chaiAsPromised)
+import promised from 'chai-as-promised'
+chai.use(promised)
 import path from 'path'
 
 import { run } from '../src/jq'
@@ -16,7 +16,7 @@ const FILTER_INVALID = 'invalid'
 
 const ERROR_INVALID_FILTER = /error: invalid/
 const ERROR_INVALID_PATH = 'Invalid path'
-const ERROR_INVALID_JSON_PATH = 'Not a .json file'
+const ERROR_INVALID_JSON_PATH = 'Not a json file'
 
 describe('jq core', () => {
   it('should fulfill its promise', () => {

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -1,6 +1,6 @@
 import chai, { expect } from 'chai'
-import chaiAsPromised from 'chai-as-promised'
-chai.use(chaiAsPromised)
+import promised from 'chai-as-promised'
+chai.use(promised)
 import path from 'path'
 
 import { run } from '../src/jq'

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,36 +1,22 @@
 import chai, { expect } from 'chai'
-import chaiAsPromised from 'chai-as-promised'
-chai.use(chaiAsPromised)
+import promised from 'chai-as-promised'
+chai.use(promised)
 import path from 'path'
 
-import { isAJsonPath, isAJson } from '../src/utils'
-
-import FIXTURE_JSON from './fixtures/1.json'
-const FIXTURE_VALID_JSON_STRING = JSON.stringify(FIXTURE_JSON)
-const FIXTURE_INVALID_JSON_STRING = 'test_invalid'
+import { isJSONPath } from '../src/utils'
 
 const PATH_FIXTURES = path.join(__dirname, 'fixtures')
 const PATH_JSON_FIXTURE = path.join(PATH_FIXTURES, '1.json')
 const PATH_JS_FIXTURE = path.join(PATH_FIXTURES, '1.js')
 
 describe('utils', () => {
-  describe('#isAJsonPath', () => {
-    it('should return true when u give a jsonpath', () => {
-      expect(isAJsonPath(PATH_JSON_FIXTURE)).to.be.true
+  describe('#isJSONPath', () => {
+    it('should return true when u give a json file', () => {
+      expect(isJSONPath(PATH_JSON_FIXTURE)).to.be.true
     })
 
-    it('should return false when u give a non-jsonpath', () => {
-      expect(isAJsonPath(PATH_JS_FIXTURE)).to.be.false
-    })
-  })
-
-  describe('#isAJson', () => {
-    it('should return true when u give a json', () => {
-      expect(isAJson(FIXTURE_VALID_JSON_STRING)).to.be.true
-    })
-
-    it('should return false when u give a non-json', () => {
-      expect(isAJson(FIXTURE_INVALID_JSON_STRING)).to.be.false
+    it('should return false when u give a non-json file', () => {
+      expect(isJSONPath(PATH_JS_FIXTURE)).to.be.false
     })
   })
 })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -11,11 +11,11 @@ const PATH_JS_FIXTURE = path.join(PATH_FIXTURES, '1.js')
 
 describe('utils', () => {
   describe('#isJSONPath', () => {
-    it('should return true when u give a json file', () => {
+    it('should return true when you give a json file', () => {
       expect(isJSONPath(PATH_JSON_FIXTURE)).to.be.true
     })
 
-    it('should return false when u give a non-json file', () => {
+    it('should return false when you a non-json file', () => {
       expect(isJSONPath(PATH_JS_FIXTURE)).to.be.false
     })
   })


### PR DESCRIPTION
Hello @mackermans 

This is the first refactor for prepare the next releases, one exporting jq.run as jq directly and the other for support json5.

The intention is to separate how we create the command and how we run it.

- Create a commandFactory.
- Remove `isAJson` util not used and his tests.
- Rename json to capital letters.
- Rename `chai-as-promised` to `promised` on the tests.