### PR TITLE
Don't parse the result on output:json if isn't a valid JS format

### DIFF
--- a/src/jq.js
+++ b/src/jq.js
@@ -7,7 +7,13 @@ export const run = (filter, json, options = {}) => {
     exec(command)
       .then((stdout) => {
         if (options.output === 'json') {
-          return resolve(JSON.parse(stdout))
+          let result
+          try {
+            result = JSON.parse(stdout)
+          } catch (error) {
+            result = stdout
+          }
+          return resolve(result)
         } else {
           return resolve(stdout)
         }

--- a/test/fixtures/1.json
+++ b/test/fixtures/1.json
@@ -1,24 +1,92 @@
-[
-  {
-    "a": 1,
-    "id": 1
-  }, {
-    "a": 2,
-    "id": 2
-  }, {
-    "a": 3,
-    "id": 3
-  }, {
-    "a": 4,
-    "id": 2
-  }, {
-    "a": 5,
-    "id": 5
-  }, {
-    "a": 6,
-    "id": 7
-  }, {
-    "a": 7,
-    "id": 8
+{
+  "name": "node-jq",
+  "version": "0.0.0-semantic-release",
+  "description": "Run jq in node",
+  "main": "lib/jq.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sanack/node-jq"
+  },
+  "scripts": {
+    "pretest": "npm run install-binary",
+    "install-binary": "node scripts/install-binary.js",
+    "test": "mocha --compilers js:babel-register",
+    "test:watch": "npm test -- --watch",
+    "lint": "standard --verbose | snazzy",
+    "build": "babel src -d lib",
+    "prepublish": "npm test && npm run lint && npm run build",
+    "postinstall": "npm run install-binary",
+    "coverage": "babel-node ./node_modules/.bin/isparta cover _mocha",
+    "precoveralls": "npm run coverage",
+    "coveralls": "coveralls < coverage/lcov.info",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+  },
+  "keywords": [
+    "jq",
+    "json"
+  ],
+  "author": "sanack",
+  "contributors": [
+    {
+      "name": "davesnx",
+      "email": "dsnxmoreno@gmail.com"
+    },
+    {
+      "name": "mackermans",
+      "email": "maarten.ackermans@gmail.com"
+    }
+  ],
+  "license": "MIT",
+  "files": [
+    "src",
+    "lib",
+    "scripts"
+  ],
+  "dependencies": {
+    "bin-build": "^2.2.0",
+    "is-valid-path": "^0.1.1",
+    "strip-eof": "^1.0.0",
+    "tempfile": "^1.1.1"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.10.1",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-stage-1": "^6.5.0",
+    "babel-register": "^6.9.0",
+    "chai": "^3.5.0",
+    "chai-as-promised": "^6.0.0",
+    "condition-circle": "^1.5.0",
+    "coveralls": "^2.11.9",
+    "ghooks": "^1.2.3",
+    "isparta": "^4.0.0",
+    "mocha": "^3.2.0",
+    "semantic-release": "^6.3.2",
+    "snazzy": "^5.0.0",
+    "standard": "^8.6.0",
+    "tap-diff": "^0.1.1",
+    "validate-commit-msg": "^2.8.2"
+  },
+  "babel": {
+    "presets": [
+      "es2015",
+      "stage-1"
+    ]
+  },
+  "standard": {
+    "global": [
+      "describe",
+      "it"
+    ]
+  },
+  "config": {
+    "ghooks": {
+      "commit-msg": "validate-commit-msg",
+      "pre-commit": "npm run lint",
+      "pre-push": "npm test"
+    }
+  },
+  "release": {
+    "verifyConditions": "condition-circle",
+    "branch": "master"
   }
-]
+}

--- a/test/jq.test.js
+++ b/test/jq.test.js
@@ -11,7 +11,7 @@ const PATH_JSON_FIXTURE = path.join(PATH_FIXTURES, '1.json')
 const PATH_JS_FIXTURE = path.join(PATH_FIXTURES, '1.js')
 const PATH_ASTERISK_FIXTURE = path.join(PATH_ROOT, 'src', '*.js')
 
-const FILTER_VALID = '. | map(select(.a == .id))'
+const FILTER_VALID = '.repository.type'
 const FILTER_INVALID = 'invalid'
 
 const ERROR_INVALID_FILTER = /error: invalid/

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -47,7 +47,7 @@ describe('options', () => {
     })
   })
 
-  describe.only('output: json', () => {
+  describe('output: json', () => {
     it('should return a json', () => {
       return expect(
         run('.', PATH_JSON_FIXTURE, { output: 'json' })

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -54,7 +54,7 @@ describe('options', () => {
       ).to.eventually.become(FIXTURE_JSON)
     })
 
-    it('should return a json in case of filter fail', () => {
+    it('it should return a string if the filter calls an array', () => {
       return expect(
         run('.contributors[]', PATH_JSON_FIXTURE, { output: 'json' })
       ).to.eventually.become(

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -48,7 +48,7 @@ describe('options', () => {
   })
 
   describe('output: json', () => {
-    it('should return a json', () => {
+    it('should return a stringified json', () => {
       return expect(
         run('.', PATH_JSON_FIXTURE, { output: 'json' })
       ).to.eventually.become(FIXTURE_JSON)

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -19,18 +19,14 @@ const OPTION_DEFAULTS = {
 }
 
 describe('options', () => {
-  describe('defaults', () => {
-    it('should be as expected', () => {
-      return expect(optionDefaults).to.deep.equal(OPTION_DEFAULTS)
-    })
+  it('defaults should be as expected', () => {
+    expect(optionDefaults).to.deep.equal(OPTION_DEFAULTS)
   })
 
   describe('input: file', () => {
     it('should accept a file path as input', () => {
       return expect(
-        run('.', PATH_JSON_FIXTURE, {
-          input: 'file'
-        })
+        run('.', PATH_JSON_FIXTURE, { input: 'file' })
       ).to.eventually.be.fulfilled
     })
   })
@@ -38,9 +34,7 @@ describe('options', () => {
   describe('input: json', () => {
     it('should accept a json object as input', () => {
       return expect(
-        run('.', FIXTURE_JSON, {
-          input: 'json'
-        })
+        run('.', FIXTURE_JSON, { input: 'json' })
       ).to.eventually.be.fulfilled
     })
   })
@@ -48,29 +42,33 @@ describe('options', () => {
   describe('input: string', () => {
     it('should accept a json string as input', () => {
       return expect(
-        run('.', FIXTURE_JSON_STRING, {
-          input: 'string'
-        })
+        run('.', FIXTURE_JSON_STRING, { input: 'string' })
       ).to.eventually.be.fulfilled
     })
   })
 
-  describe('output: json', () => {
-    it('should return a minified json string', () => {
+  describe.only('output: json', () => {
+    it('should return a json', () => {
       return expect(
-        run('.', PATH_JSON_FIXTURE, {
-          output: 'json'
-        })
+        run('.', PATH_JSON_FIXTURE, { output: 'json' })
       ).to.eventually.become(FIXTURE_JSON)
+    })
+
+    it('should return a json in case of filter fail', () => {
+      return expect(
+        run('.contributors[]', PATH_JSON_FIXTURE, { output: 'json' })
+      ).to.eventually.become(
+        JSON.stringify(FIXTURE_JSON.contributors[0], null, 2) +
+        '\n' +
+        JSON.stringify(FIXTURE_JSON.contributors[1], null, 2)
+      )
     })
   })
 
   describe('output: string', () => {
     it('should return a minified json string', () => {
       return expect(
-        run('.', PATH_JSON_FIXTURE, {
-          output: 'string'
-        })
+        run('.', PATH_JSON_FIXTURE, { output: 'string' })
       ).to.eventually.become(FIXTURE_JSON_STRING)
     })
   })
@@ -78,9 +76,7 @@ describe('options', () => {
   describe('output: pretty', () => {
     it('should return a prettified json string', () => {
       return expect(
-        run('.', PATH_JSON_FIXTURE, {
-          output: 'pretty'
-        })
+        run('.', PATH_JSON_FIXTURE, { output: 'pretty' })
       ).to.eventually.become(FIXTURE_JSON_PRETTY)
     })
   })


### PR DESCRIPTION
Hello @mackermans and @wellsjo

- Add a test case for ur use case.
- Try to parse the output as a JSON, if we can't we pass it directly. That will affect, numbers, strings and arrays. It's the minimum effort to not break the API of the output.

As you can see in the test, the output of
```bash
jq_ "{ prop: [1,2,3] } | .prop[]" --null-input
# becomes
1
2
3
```

That means that you can't actually parse this string of `"1\n2\n3\n"` with JavaScript. Thinking a solution like sending back the type of the source of the result could be a nice one, but we need to be sure that matches without properties of output. 

I keep this 3 series of PR lately keeping in mind that the repetition is better than the wrong abstraction and a small patch here with good test coverage can be improved drastically at the end of the day if we found the good generalization.

PS: I'm preparing the 0.5.0 release for this week with some improvements. I will ping and try to update it on JSON-Splora.



Closes #52 