### PR TITLE
Windows compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   ],
   "dependencies": {
     "bin-build": "^2.2.0",
+    "download": "^5.0.2",
     "is-valid-path": "^0.1.1",
     "strip-eof": "^1.0.0",
     "tempfile": "^1.1.1"

--- a/scripts/install-binary.js
+++ b/scripts/install-binary.js
@@ -6,6 +6,10 @@ const BinBuild = require('bin-build')
 const path = require('path')
 const tempfile = require('tempfile')
 const fs = require('fs')
+const download = require('download')
+
+const platform = process.platform
+const arch = process.arch
 
 const JQ_INFO = {
   name: 'jq',
@@ -13,11 +17,17 @@ const JQ_INFO = {
   version: 'jq-1.5'
 }
 
+const JQ_NAME_MAP = {
+  'def': 'jq',
+  'win32': 'jq.exe'
+}
+const JQ_NAME = (platform in JQ_NAME_MAP) ? JQ_NAME_MAP[platform] : JQ_NAME_MAP.def
+
 const OUTPUT_DIR = path.join(__dirname, '..', 'bin')
 
 const jqExists = () => {
   try {
-    return fs.statSync((path.join(OUTPUT_DIR, 'jq'))).isFile()
+    return fs.statSync((path.join(OUTPUT_DIR, JQ_NAME))).isFile()
   } catch (err) {
     return false
   }
@@ -28,15 +38,39 @@ if (jqExists()) {
   process.exit(0)
 }
 
-const build = new BinBuild()
-  .src(`${JQ_INFO.url}/${JQ_INFO.version}/${JQ_INFO.version}.tar.gz`)
-  .cmd(`./configure --disable-maintainer-mode --bindir=${OUTPUT_DIR} --libdir=${tempfile()}`)
-  .cmd('make')
-  .cmd('make install')
-
-build.run((err) => {
-  if (err) {
-    console.log(`Err: ${err}`)
+// if platform is missing, download source instead of executable
+const DOWNLOAD_MAP = {
+  'win32': {
+    'def': 'jq-win32.exe',
+    'x64': 'jq-win64.exe'
   }
-  console.log(`jq installed successfully on ${OUTPUT_DIR}`)
-})
+}
+
+if (platform in DOWNLOAD_MAP) {
+  // download the executable
+
+  const filename = (arch in DOWNLOAD_MAP[platform]) ? DOWNLOAD_MAP[platform][arch] : DOWNLOAD_MAP[platform].def
+  const url = `${JQ_INFO.url}${JQ_INFO.version}/${filename}`
+
+  console.log(`Downloading jq from ${url}`)
+  download(url, OUTPUT_DIR).then(() => {
+    fs.renameSync(path.join(OUTPUT_DIR, filename), path.join(OUTPUT_DIR, JQ_NAME))
+    console.log(`Downloaded in ${OUTPUT_DIR}`)
+  })
+} else {
+  // download source and build
+
+  const build = new BinBuild()
+    .src(`${JQ_INFO.url}/${JQ_INFO.version}/${JQ_INFO.version}.tar.gz`)
+    .cmd(`./configure --disable-maintainer-mode --bindir=${OUTPUT_DIR} --libdir=${tempfile()}`)
+    .cmd('make')
+    .cmd('make install')
+
+  build.run((err) => {
+    if (err) {
+      console.log(`Err: ${err}`)
+    } else {
+      console.log(`jq installed successfully on ${OUTPUT_DIR}`)
+    }
+  })
+}

--- a/scripts/install-binary.js
+++ b/scripts/install-binary.js
@@ -62,7 +62,7 @@ if (platform in DOWNLOAD_MAP) {
 
   const build = new BinBuild()
     .src(`${JQ_INFO.url}/${JQ_INFO.version}/${JQ_INFO.version}.tar.gz`)
-    .cmd(`./configure --disable-maintainer-mode --bindir=${OUTPUT_DIR} --libdir=${tempfile()}`)
+    .cmd(`./configure --disable-maintainer-mode --prefix=${tempfile()} --bindir=${OUTPUT_DIR}`)
     .cmd('make')
     .cmd('make install')
 

--- a/test/fixtures/1.json
+++ b/test/fixtures/1.json
@@ -7,25 +7,6 @@
     "type": "git",
     "url": "https://github.com/sanack/node-jq"
   },
-  "scripts": {
-    "pretest": "npm run install-binary",
-    "install-binary": "node scripts/install-binary.js",
-    "test": "mocha --compilers js:babel-register",
-    "test:watch": "npm test -- --watch",
-    "lint": "standard --verbose | snazzy",
-    "build": "babel src -d lib",
-    "prepublish": "npm test && npm run lint && npm run build",
-    "postinstall": "npm run install-binary",
-    "coverage": "babel-node ./node_modules/.bin/isparta cover _mocha",
-    "precoveralls": "npm run coverage",
-    "coveralls": "coveralls < coverage/lcov.info",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
-  },
-  "keywords": [
-    "jq",
-    "json"
-  ],
-  "author": "sanack",
   "contributors": [
     {
       "name": "davesnx",
@@ -35,58 +16,5 @@
       "name": "mackermans",
       "email": "maarten.ackermans@gmail.com"
     }
-  ],
-  "license": "MIT",
-  "files": [
-    "src",
-    "lib",
-    "scripts"
-  ],
-  "dependencies": {
-    "bin-build": "^2.2.0",
-    "is-valid-path": "^0.1.1",
-    "strip-eof": "^1.0.0",
-    "tempfile": "^1.1.1"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.10.1",
-    "babel-preset-es2015": "^6.9.0",
-    "babel-preset-stage-1": "^6.5.0",
-    "babel-register": "^6.9.0",
-    "chai": "^3.5.0",
-    "chai-as-promised": "^6.0.0",
-    "condition-circle": "^1.5.0",
-    "coveralls": "^2.11.9",
-    "ghooks": "^1.2.3",
-    "isparta": "^4.0.0",
-    "mocha": "^3.2.0",
-    "semantic-release": "^6.3.2",
-    "snazzy": "^5.0.0",
-    "standard": "^8.6.0",
-    "tap-diff": "^0.1.1",
-    "validate-commit-msg": "^2.8.2"
-  },
-  "babel": {
-    "presets": [
-      "es2015",
-      "stage-1"
-    ]
-  },
-  "standard": {
-    "global": [
-      "describe",
-      "it"
-    ]
-  },
-  "config": {
-    "ghooks": {
-      "commit-msg": "validate-commit-msg",
-      "pre-commit": "npm run lint",
-      "pre-push": "npm test"
-    }
-  },
-  "release": {
-    "verifyConditions": "condition-circle",
-    "branch": "master"
-  }
+  ]
 }

--- a/test/jq.test.js
+++ b/test/jq.test.js
@@ -6,7 +6,7 @@ import path from 'path'
 import { run } from '../src/jq'
 
 const PATH_ROOT = path.join(__dirname, '..')
-const PATH_FIXTURES = path.join(__dirname, 'fixtures')
+const PATH_FIXTURES = path.join('test', 'fixtures')
 const PATH_JSON_FIXTURE = path.join(PATH_FIXTURES, '1.json')
 const PATH_JS_FIXTURE = path.join(PATH_FIXTURES, '1.js')
 const PATH_ASTERISK_FIXTURE = path.join(PATH_ROOT, 'src', '*.js')

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -18,6 +18,10 @@ const OPTION_DEFAULTS = {
   output: 'pretty'
 }
 
+const multiEOL = (text) => {
+  return [text, text.replace(/\n/g, '\r\n')]
+}
+
 describe('options', () => {
   it('defaults should be as expected', () => {
     expect(optionDefaults).to.deep.equal(OPTION_DEFAULTS)
@@ -57,11 +61,11 @@ describe('options', () => {
     it('it should return a string if the filter calls an array', () => {
       return expect(
         run('.contributors[]', PATH_JSON_FIXTURE, { output: 'json' })
-      ).to.eventually.become(
+      ).to.eventually.deep.oneOf(multiEOL(
         JSON.stringify(FIXTURE_JSON.contributors[0], null, 2) +
         '\n' +
         JSON.stringify(FIXTURE_JSON.contributors[1], null, 2)
-      )
+      ))
     })
   })
 
@@ -77,7 +81,7 @@ describe('options', () => {
     it('should return a prettified json string', () => {
       return expect(
         run('.', PATH_JSON_FIXTURE, { output: 'pretty' })
-      ).to.eventually.deep.oneOf([FIXTURE_JSON_PRETTY, FIXTURE_JSON_PRETTY.replace(/\n/g, '\r\n')])
+      ).to.eventually.deep.oneOf(multiEOL(FIXTURE_JSON_PRETTY))
     })
   })
 })

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -6,12 +6,12 @@ import path from 'path'
 import { run } from '../src/jq'
 import { optionDefaults } from '../src/options'
 
-const PATH_FIXTURES = path.join(__dirname, 'fixtures')
+const PATH_FIXTURES = path.join('test', 'fixtures')
 const PATH_JSON_FIXTURE = path.join(PATH_FIXTURES, '1.json')
 
-const FIXTURE_JSON = require(PATH_JSON_FIXTURE)
+const FIXTURE_JSON = require('./fixtures/1.json')
 const FIXTURE_JSON_STRING = JSON.stringify(FIXTURE_JSON)
-const FIXTURE_JSON_PRETTY = JSON.stringify(FIXTURE_JSON, null, 2)
+const FIXTURE_JSON_PRETTY = JSON.stringify(FIXTURE_JSON, null, 2).replace(/\n/g, '\r\n')
 
 const OPTION_DEFAULTS = {
   input: 'file',

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -11,7 +11,7 @@ const PATH_JSON_FIXTURE = path.join(PATH_FIXTURES, '1.json')
 
 const FIXTURE_JSON = require('./fixtures/1.json')
 const FIXTURE_JSON_STRING = JSON.stringify(FIXTURE_JSON)
-const FIXTURE_JSON_PRETTY = JSON.stringify(FIXTURE_JSON, null, 2).replace(/\n/g, '\r\n')
+const FIXTURE_JSON_PRETTY = JSON.stringify(FIXTURE_JSON, null, 2)
 
 const OPTION_DEFAULTS = {
   input: 'file',
@@ -77,7 +77,7 @@ describe('options', () => {
     it('should return a prettified json string', () => {
       return expect(
         run('.', PATH_JSON_FIXTURE, { output: 'pretty' })
-      ).to.eventually.become(FIXTURE_JSON_PRETTY)
+      ).to.eventually.deep.oneOf([FIXTURE_JSON_PRETTY, FIXTURE_JSON_PRETTY.replace(/\n/g, '\r\n')])
     })
   })
 })


### PR DESCRIPTION
## Install binaries
Jq can't be build by a command in windows, there is no config file for windows yet.
My solution to this is to download the executable and not the source.

So I use a map to find which file is the executable for the platform and arch:
```js
const DOWNLOAD_MAP = {
  'win32': {
    'def': 'jq-win32.exe',
    'x64': 'jq-win64.exe'
  }
}
```
If the platform is not in the map the old ways apply (download, config, make).
If you want you can add more this like:
```js
const DOWNLOAD_MAP = {
  'win32': {
    'def': 'jq-win32.exe',
    'x64': 'jq-win64.exe'
  },
  'linux': {
    'def': 'jq-linux32',
    'x64': 'jq-linux64'
  }
}
```

#### Notes
- A `win32` platform can be 64-bit
- Made the executable filename variable because in windows is `jq.exe` and not `jq`
- The dep `download` that I added is already used by the `bin-build`

## Paths and Tests
The absolute paths is not the problem, the problem is the size of the path.
It is an [issue](https://github.com/stedolan/jq/issues/1205) in jq.

Temporarily I made the paths in the tests relative (= smaller) so they can run.

#### Notes
- The stringify returns only `\n` instead of `\r\n` so I did a fast replacement

## More text
Solves #54 that I opened. 
Hope you appreciate my effort, waiting feedback.

