### PR TITLE
feat(jq): added ability to optionally specify jq binary location

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ jq.run(filter, jsonPath, options)
 
 ## Options
 
+### path to jq binary
+
+By default, the jq binary installed with the package is used.
+If you have special needs or want to use another binary in a different
+path you can set the environment variable JQ_PATH to override the default
+behaviour.
+
 ### input
 |  Description  |  Type  |             Values             |  Default |
 |:-------------:|:------:|:------------------------------:|:--------:|

--- a/src/command.js
+++ b/src/command.js
@@ -1,7 +1,7 @@
 import path from 'path'
 import { parseOptions } from './options'
 
-const JQ_PATH = path.join(__dirname, '..', 'bin', 'jq')
+const JQ_PATH = process.env.JQ_PATH || path.join(__dirname, '..', 'bin', 'jq')
 
 export const commandFactory = (filter, json, options = {}) => {
   return {


### PR DESCRIPTION
Makes it possible to control where the jq binary that should by used is located.

I'm using this on AWS Lambda where I add the jq binary using a lambda layer. Unfortunately one is limited in controlling where AWS puts the binary. So this is useful for anyone who does not want or is not able to use the default binary location.

I also updated the docs :)