### PR TITLE
fix(stdin): throw errors on invalid input

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -4,6 +4,13 @@ import { validateJSONPath } from './utils'
 
 const JQ_PATH = process.env.JQ_PATH || path.join(__dirname, '..', 'bin', 'jq')
 
+export const FILTER_UNDEFINED_ERROR =
+  'node-jq: invalid filter argument supplied: "undefined"'
+export const INPUT_JSON_UNDEFINED_ERROR =
+  'node-jq: invalid json object argument supplied: "undefined"'
+export const INPUT_STRING_ERROR =
+  'node-jq: invalid json string argument supplied'
+
 const getFileArray = path => {
   if (Array.isArray(path)) {
     return path.reduce((array, file) => {
@@ -15,11 +22,33 @@ const getFileArray = path => {
   return [path]
 }
 
+const validateArguments = (filter, json, options) => {
+  if (typeof filter === 'undefined') {
+    throw new Error(FILTER_UNDEFINED_ERROR)
+  }
+
+  switch (options.input) {
+    case 'json':
+      if (typeof json === 'undefined') {
+        throw new Error(INPUT_JSON_UNDEFINED_ERROR)
+      }
+      break
+    case 'string':
+      if (!json) {
+        throw new Error(`${INPUT_STRING_ERROR}: "${json === '' ? '' : json}"`)
+      }
+      break
+  }
+}
+
 export const commandFactory = (filter, json, options = {}) => {
   const mergedOptions = {
     ...optionDefaults,
     ...options
   }
+
+  validateArguments(filter, json, mergedOptions)
+
   let args = [filter, ...parseOptions(mergedOptions)]
   let stdin = ''
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,18 +1,20 @@
 import isPathValid from 'is-valid-path'
 
-const INVALID_PATH_ERROR = 'Invalid path'
-const INVALID_JSON_PATH_ERROR = 'Not a json file'
+export const INVALID_PATH_ERROR =
+  'node-jq: invalid path argument supplied (not a valid path)'
+export const INVALID_JSON_PATH_ERROR =
+  'node-jq: invalid path argument supplied (not a .json file)'
 
-export const isJSONPath = (path) => {
+export const isJSONPath = path => {
   return /\.json$/.test(path)
 }
 
-export const validateJSONPath = (JSONFile) => {
-  if (!isPathValid(JSONFile)) {
-    throw (Error(INVALID_PATH_ERROR))
+export const validateJSONPath = path => {
+  if (!isPathValid(path)) {
+    throw new Error(`${INVALID_PATH_ERROR}: "${path}"`)
   }
 
-  if (!isJSONPath(JSONFile)) {
-    throw (Error(INVALID_JSON_PATH_ERROR))
+  if (!isJSONPath(path)) {
+    throw new Error(`${INVALID_JSON_PATH_ERROR}: "${path === '' ? '' : path}"`)
   }
 }

--- a/test/jq.test.js
+++ b/test/jq.test.js
@@ -28,7 +28,7 @@ describe('jq core', () => {
   it('should fulfill its promise', done => {
     run(FILTER_VALID, PATH_JSON_FIXTURE)
       .then(output => {
-        expect(output).to.be.a('string')
+        expect(output).to.equal('"git"')
         done()
       })
       .catch(error => {

--- a/test/jq.test.js
+++ b/test/jq.test.js
@@ -39,7 +39,8 @@ describe('jq core', () => {
   it('should pass on an empty filter', done => {
     run('', PATH_JSON_FIXTURE)
       .then(output => {
-        expect(output).to.equal(FIXTURE_JSON_STRING)
+        const normalizedOutput = output.replace(/\r\n/g, '\n')
+        expect(normalizedOutput).to.equal(FIXTURE_JSON_STRING)
         done()
       })
       .catch(error => {

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -3,6 +3,8 @@ import path from 'path'
 
 import { run } from '../src/jq'
 import { optionDefaults } from '../src/options'
+import { INPUT_JSON_UNDEFINED_ERROR, INPUT_STRING_ERROR } from '../src/command'
+import { INVALID_PATH_ERROR, INVALID_JSON_PATH_ERROR } from '../src/utils'
 
 const PATH_FIXTURES = path.join('test', 'fixtures')
 const PATH_JSON_FIXTURE = path.join(PATH_FIXTURES, '1.json')
@@ -22,7 +24,7 @@ const OPTION_DEFAULTS = {
   raw: false
 }
 
-const multiEOL = (text) => {
+const multiEOL = text => {
   return [text, text.replace(/\n/g, '\r\n')]
 }
 
@@ -31,192 +33,288 @@ describe('options', () => {
     expect(optionDefaults).to.deep.equal(OPTION_DEFAULTS)
   })
 
-  describe('input: file', () => {
-    it('should accept a file path as input', (done) => {
-      run('.', PATH_JSON_FIXTURE, { input: 'file' })
-        .then((output) => {
-          expect(output).to.not.equal(null)
-          done()
-        })
-        .catch((error) => {
-          done(error)
-        })
+  describe('input', () => {
+    describe('file', () => {
+      it('should accept a file path as input', done => {
+        run('.', PATH_JSON_FIXTURE, { input: 'file' })
+          .then(output => {
+            expect(output).to.not.equal(null)
+            done()
+          })
+          .catch(error => {
+            done(error)
+          })
+      })
+
+      it('should accept an array with multiple file paths as input', done => {
+        run('.', [PATH_JSON_FIXTURE, PATH_JSON_FIXTURE], { input: 'file' })
+          .then(output => {
+            expect(output).to.not.equal(null)
+            done()
+          })
+          .catch(error => {
+            done(error)
+          })
+      })
+
+      it('should fail on an empty path', done => {
+        run('.', '', { input: 'file' })
+          .catch(error => {
+            expect(error).to.be.an.instanceof(Error)
+            expect(error.message).to.equal(`${INVALID_JSON_PATH_ERROR}: ""`)
+            done()
+          })
+          .catch(error => {
+            done(error)
+          })
+      })
+
+      it('should fail on a null path', done => {
+        run('.', null, { input: 'file' })
+          .catch(error => {
+            expect(error).to.be.an.instanceof(Error)
+            expect(error.message).to.equal(`${INVALID_PATH_ERROR}: "null"`)
+            done()
+          })
+          .catch(error => {
+            done(error)
+          })
+      })
+
+      it('should fail on an undefined path', done => {
+        run('.', undefined, { input: 'file' })
+          .catch(error => {
+            expect(error).to.be.an.instanceof(Error)
+            expect(error.message).to.equal(`${INVALID_PATH_ERROR}: "undefined"`)
+            done()
+          })
+          .catch(error => {
+            done(error)
+          })
+      })
+    })
+
+    describe('json', () => {
+      it('should accept a json object as input', done => {
+        run('.', FIXTURE_JSON, { input: 'json' })
+          .then(output => {
+            expect(output).to.not.equal(null)
+            done()
+          })
+          .catch(error => {
+            done(error)
+          })
+      })
+
+      it('should accept an empty string as json object', done => {
+        run('.', '', { input: 'json' })
+          .then(output => {
+            expect(output).to.equal('""')
+            done()
+          })
+          .catch(error => {
+            done(error)
+          })
+      })
+
+      it('should accept a null json object', done => {
+        run('.', null, { input: 'json' })
+          .then(output => {
+            expect(output).to.equal('null')
+            done()
+          })
+          .catch(error => {
+            done(error)
+          })
+      })
+
+      it('should fail on an undefined json object', done => {
+        run('.', undefined, { input: 'json' })
+          .catch(error => {
+            expect(error).to.be.an.instanceof(Error)
+            expect(error.message).to.equal(INPUT_JSON_UNDEFINED_ERROR)
+            done()
+          })
+          .catch(error => {
+            done(error)
+          })
+      })
+    })
+
+    describe('string', () => {
+      it('should accept a json string as input', done => {
+        run('.', FIXTURE_JSON_STRING, { input: 'string' })
+          .then(output => {
+            expect(output).to.not.equal(null)
+            done()
+          })
+          .catch(error => {
+            done(error)
+          })
+      })
+
+      it('should fail on an empty string', done => {
+        run('.', '', { input: 'string' })
+          .catch(error => {
+            expect(error).to.be.an.instanceof(Error)
+            expect(error.message).to.equal(`${INPUT_STRING_ERROR}: ""`)
+            done()
+          })
+          .catch(error => {
+            done(error)
+          })
+      })
+
+      it('should fail on a null string', done => {
+        run('.', null, { input: 'string' })
+          .catch(error => {
+            expect(error).to.be.an.instanceof(Error)
+            expect(error.message).to.equal(`${INPUT_STRING_ERROR}: "null"`)
+            done()
+          })
+          .catch(error => {
+            done(error)
+          })
+      })
+
+      it('should fail on an undefined string', done => {
+        run('.', undefined, { input: 'string' })
+          .catch(error => {
+            expect(error).to.be.an.instanceof(Error)
+            expect(error.message).to.equal(`${INPUT_STRING_ERROR}: "undefined"`)
+            done()
+          })
+          .catch(error => {
+            done(error)
+          })
+      })
     })
   })
 
-  describe('input: file', () => {
-    it('should accept an array with multiple file paths as input', (done) => {
-      run('.', [
-        PATH_JSON_FIXTURE,
-        PATH_JSON_FIXTURE
-      ], { input: 'file' })
-        .then((output) => {
-          expect(output).to.not.equal(null)
-          done()
-        })
-        .catch((error) => {
-          done(error)
-        })
-    })
-  })
+  describe('output', () => {
+    describe('json', () => {
+      it('should return a stringified json', done => {
+        run('.', PATH_JSON_FIXTURE, { output: 'json' })
+          .then(obj => {
+            expect(obj).to.deep.equal(FIXTURE_JSON)
+            done()
+          })
+          .catch(error => {
+            done(error)
+          })
+      })
 
-  describe('input: json', () => {
-    it('should accept a json object as input', (done) => {
-      run('.', FIXTURE_JSON, { input: 'json' })
-        .then((output) => {
-          expect(output).to.not.equal(null)
-          done()
-        })
-        .catch((error) => {
-          done(error)
-        })
-    })
-  })
-
-  describe('input: string', () => {
-    it('should accept a json string as input', (done) => {
-      run('.', FIXTURE_JSON_STRING, { input: 'string' })
-        .then((output) => {
-          expect(output).to.not.equal(null)
-          done()
-        })
-        .catch((error) => {
-          done(error)
-        })
-    })
-  })
-
-  describe('output: json', () => {
-    it('should return a stringified json', (done) => {
-      run('.', PATH_JSON_FIXTURE, { output: 'json' })
-        .then((obj) => {
-          expect(obj).to.deep.equal(FIXTURE_JSON)
-          done()
-        })
-        .catch((error) => {
-          done(error)
-        })
-    })
-
-    it('it should return a string if the filter calls an array', (done) => {
-      run('.contributors[]', PATH_JSON_FIXTURE, { output: 'json' })
-        .then((obj) => {
-          expect(obj).to.be.oneOf(
-            multiEOL(
-              JSON.stringify(FIXTURE_JSON.contributors[0], null, 2) +
-            '\n' +
-            JSON.stringify(FIXTURE_JSON.contributors[1], null, 2)
+      it('it should return a string if the filter calls an array', done => {
+        run('.contributors[]', PATH_JSON_FIXTURE, { output: 'json' })
+          .then(obj => {
+            expect(obj).to.be.oneOf(
+              multiEOL(
+                JSON.stringify(FIXTURE_JSON.contributors[0], null, 2) +
+                  '\n' +
+                  JSON.stringify(FIXTURE_JSON.contributors[1], null, 2)
+              )
             )
-          )
-          done()
-        })
-        .catch((error) => {
-          done(error)
-        })
+            done()
+          })
+          .catch(error => {
+            done(error)
+          })
+      })
     })
-  })
 
-  describe('output: string', () => {
-    it('should return a minified json string', (done) => {
-      run('.', PATH_JSON_FIXTURE, { output: 'string' })
-        .then((output) => {
-          expect(output).to.equal(FIXTURE_JSON_STRING)
-          done()
-        })
-        .catch((error) => {
-          done(error)
-        })
+    describe('string', () => {
+      it('should return a minified json string', done => {
+        run('.', PATH_JSON_FIXTURE, { output: 'string' })
+          .then(output => {
+            expect(output).to.equal(FIXTURE_JSON_STRING)
+            done()
+          })
+          .catch(error => {
+            done(error)
+          })
+      })
     })
-  })
 
-  describe('output: compact', () => {
-    it('should return a minified json string', (done) => {
-      run('.', PATH_JSON_FIXTURE, { output: 'compact' })
-        .then((output) => {
-          expect(output).to.equal(FIXTURE_JSON_STRING)
-          done()
-        })
-        .catch((error) => {
-          done(error)
-        })
+    describe('compact', () => {
+      it('should return a minified json string', done => {
+        run('.', PATH_JSON_FIXTURE, { output: 'compact' })
+          .then(output => {
+            expect(output).to.equal(FIXTURE_JSON_STRING)
+            done()
+          })
+          .catch(error => {
+            done(error)
+          })
+      })
     })
-  })
 
-  describe('output: pretty', () => {
-    it('should return a prettified json string', (done) => {
-      run('.', PATH_JSON_FIXTURE, { output: 'pretty' })
-        .then((output) => {
-          expect(output).to.be.oneOf(
-            multiEOL(FIXTURE_JSON_PRETTY)
-          )
-          done()
-        })
-        .catch((error) => {
-          done(error)
-        })
+    describe('pretty', () => {
+      it('should return a prettified json string', done => {
+        run('.', PATH_JSON_FIXTURE, { output: 'pretty' })
+          .then(output => {
+            expect(output).to.be.oneOf(multiEOL(FIXTURE_JSON_PRETTY))
+            done()
+          })
+          .catch(error => {
+            done(error)
+          })
+      })
     })
   })
 
   describe('slurp: true', () => {
-    it('should run the filter once on multiple objects as input', (done) => {
-      run('.', [
-        PATH_SLURP_FIXTURE_1,
-        PATH_SLURP_FIXTURE_2
-      ], {
+    it('should run the filter once on multiple objects as input', done => {
+      run('.', [PATH_SLURP_FIXTURE_1, PATH_SLURP_FIXTURE_2], {
         output: 'json',
         slurp: true
       })
-        .then((output) => {
+        .then(output => {
           expect(output).to.be.an('array')
           expect(output).to.have.lengthOf(2)
           done()
         })
-        .catch((error) => {
+        .catch(error => {
           done(error)
         })
     })
   })
 
   describe('sort: false', () => {
-    it('keys should be ordered the same as in input file', (done) => {
-      run('.', [
-        PATH_SORT_FIXTURE
-      ], {
+    it('keys should be ordered the same as in input file', done => {
+      run('.', [PATH_SORT_FIXTURE], {
         output: 'string',
         sort: false
       })
-        .then((output) => {
+        .then(output => {
           expect(output).to.be.a('string')
           expect(output).to.eql('{"z":1,"a":2}')
           done()
         })
-        .catch((error) => {
+        .catch(error => {
           done(error)
         })
     })
   })
 
   describe('sort: true', () => {
-    it('keys should be ordered alphabetically', (done) => {
-      run('.', [
-        PATH_SORT_FIXTURE
-      ], {
+    it('keys should be ordered alphabetically', done => {
+      run('.', [PATH_SORT_FIXTURE], {
         output: 'string',
         sort: true
       })
-        .then((output) => {
+        .then(output => {
           expect(output).to.be.a('string')
           expect(output).to.eql('{"a":2,"z":1}')
           done()
         })
-        .catch((error) => {
+        .catch(error => {
           done(error)
         })
     })
   })
 
   describe('raw: true', () => {
-    it('output should be able to output raw strings instead of JSON texts', (done) => {
+    it('output should be able to output raw strings instead of JSON texts', done => {
       run('.name', PATH_JSON_FIXTURE, {
         input: 'file',
         raw: true
@@ -228,7 +326,7 @@ describe('options', () => {
         .catch(e => done(e))
     })
 
-    it('output should be able to output JSON texts instead of raw strings', (done) => {
+    it('output should be able to output JSON texts instead of raw strings', done => {
       run('.name', PATH_JSON_FIXTURE, {
         input: 'file',
         raw: false


### PR DESCRIPTION
Replicates behavior prior to addition of stdin feature (PR #194) and fixes #195 

A future release could drop some of these errors and actually handle invalid input gracefully - that would require a breaking/major release.

(Apologies for the big diff, linter at work)