### PR TITLE
Use Joi for validation & typescript definitions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceFolder}\\lib\\jq.js"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Mocha Tests",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "args": [
+                "--require",
+                "babel-core/register",
+                "--global",
+                "describe,it",
+                "--timeout",
+                "999999",
+                "--colors",
+                "${workspaceFolder}/test"
+            ],
+            "internalConsoleOptions": "openOnSessionStart"
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "docs"
   ],
   "dependencies": {
+    "@hapi/joi": "16.0.0-preview",
     "bin-build": "^3.0.0",
     "download": "^7.1.0",
     "is-valid-path": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "nyc mocha --require babel-core/register",
     "test:watch": "npm test -- --watch",
     "lint": "standard --verbose | snazzy",
-    "build": "babel src -d lib",
+    "build": "babel src -d lib --copy-files",
     "postinstall": "npm run install-binary",
     "coverage": "nyc report --reporter=lcov",
     "precodeclimate": "npm run coverage",
@@ -48,6 +48,7 @@
   ],
   "dependencies": {
     "@hapi/joi": "16.0.0-preview",
+    "@types/hapi__joi": "^15.0.3",
     "bin-build": "^3.0.0",
     "download": "^7.1.0",
     "is-valid-path": "^0.1.1",

--- a/src/command.d.ts
+++ b/src/command.d.ts
@@ -1,0 +1,15 @@
+import { PartialOptions } from "./options";
+
+export const FILTER_UNDEFINED_ERROR =
+    'node-jq: invalid filter argument supplied: "undefined"'
+export const INPUT_JSON_UNDEFINED_ERROR =
+    'node-jq: invalid json object argument supplied: "undefined"'
+export const INPUT_STRING_ERROR =
+    'node-jq: invalid json string argument supplied'
+
+interface ICommand {
+    command: string,
+    args: string[],
+    stdin: string
+}
+export function commandFactory(filter: string, json: any, options?: PartialOptions, jqPath?: string): ICommand

--- a/src/command.js
+++ b/src/command.js
@@ -1,6 +1,6 @@
+import * as Joi from '@hapi/joi'
 import path from 'path'
-import { parseOptions, optionDefaults } from './options'
-import { validateJSONPath } from './utils'
+import { parseOptions, optionsSchema, preSpawnSchema, spawnSchema } from './options'
 
 const JQ_PATH = process.env.JQ_PATH || path.join(__dirname, '..', 'bin', 'jq')
 
@@ -11,60 +11,44 @@ export const INPUT_JSON_UNDEFINED_ERROR =
 export const INPUT_STRING_ERROR =
   'node-jq: invalid json string argument supplied'
 
-const getFileArray = path => {
-  if (Array.isArray(path)) {
-    return path.reduce((array, file) => {
-      validateJSONPath(file)
-      return [...array, file]
-    }, [])
-  }
-  validateJSONPath(path)
-  return [path]
+const NODE_JQ_ERROR_TEMPLATE = `node-jq: invalid {#label} ` +
+  `argument supplied{if(#label == "path" && #type == "json", " (not a .json file)", "")}` +
+  `{if(#label == "path" && #type == "path", " (not a valid path)", "")}: ` +
+  `"{if(#value != undefined, #value, "undefined")}"`
+
+const messages = {
+  'any.invalid': NODE_JQ_ERROR_TEMPLATE,
+  'any.required': NODE_JQ_ERROR_TEMPLATE,
+  'string.base': NODE_JQ_ERROR_TEMPLATE,
+  'string.empty': NODE_JQ_ERROR_TEMPLATE
 }
 
 const validateArguments = (filter, json, options) => {
-  if (typeof filter === 'undefined') {
-    throw new Error(FILTER_UNDEFINED_ERROR)
-  }
+  const context = { filter, json }
+  const validatedOptions = Joi.attempt(options, optionsSchema)
+  const validatedPreSpawn = Joi.attempt(context, preSpawnSchema.tailor(validatedOptions.input), { messages })
+  const validatedArgs = parseOptions(validatedOptions, validatedPreSpawn.filter, validatedPreSpawn.json)
+  const validatedSpawn = Joi.attempt({}, spawnSchema.tailor(validatedOptions.input), { context: { ...validatedPreSpawn, options: validatedOptions } })
 
-  switch (options.input) {
-    case 'json':
-      if (typeof json === 'undefined') {
-        throw new Error(INPUT_JSON_UNDEFINED_ERROR)
-      }
-      break
-    case 'string':
-      if (!json) {
-        throw new Error(`${INPUT_STRING_ERROR}: "${json === '' ? '' : json}"`)
-      }
-      break
+  if (validatedOptions.input === 'file') {
+    return {
+      args: validatedArgs,
+      stdin: validatedSpawn.stdin
+    }
+  }
+  return {
+    args: validatedArgs,
+    stdin: validatedSpawn.stdin
   }
 }
 
-export const commandFactory = (filter, json, options = {}) => {
-  const mergedOptions = {
-    ...optionDefaults,
-    ...options
-  }
-
-  validateArguments(filter, json, mergedOptions)
-
-  let args = [filter, ...parseOptions(mergedOptions)]
-  let stdin = ''
-
-  if (mergedOptions.input === 'file') {
-    args = [...args, ...getFileArray(json)]
-  } else {
-    if (mergedOptions.input === 'json') {
-      stdin = JSON.stringify(json)
-    } else {
-      stdin = json
-    }
-  }
+export const commandFactory = (filter, json, options = {}, jqPath) => {
+  const command = jqPath ? path.join(jqPath, './jq') : JQ_PATH
+  const result = validateArguments(filter, json, options)
 
   return {
-    command: JQ_PATH,
-    args,
-    stdin
+    command,
+    args: result.args,
+    stdin: result.stdin
   }
 }

--- a/src/exec.d.ts
+++ b/src/exec.d.ts
@@ -1,0 +1,3 @@
+import * as childProcess from "child_process";
+
+export default function(command: string, args: string[], stdin: string, spawnOptions?: childProcess.SpawnOptions): Promise<string>

--- a/src/exec.d.ts
+++ b/src/exec.d.ts
@@ -1,3 +1,1 @@
-import * as childProcess from "child_process";
-
-export default function(command: string, args: string[], stdin: string, spawnOptions?: childProcess.SpawnOptions): Promise<string>
+export default function(command: string, args: string[], stdin: string, cwd?: string): Promise<string>

--- a/src/exec.js
+++ b/src/exec.js
@@ -1,10 +1,14 @@
 import childProcess from 'child_process'
 import stripFinalNewline from 'strip-final-newline'
 
-const exec = (command, args, stdin, spawnOptions) => {
+const TEN_MEBIBYTE = 1024 * 1024 * 10
+
+const exec = (command, args, stdin, cwd) => {
   return new Promise((resolve, reject) => {
     var stdout = ''
     var stderr = ''
+
+    const spawnOptions = { maxBuffer: TEN_MEBIBYTE, cwd }
 
     const process = childProcess.spawn(command, args, spawnOptions)
 

--- a/src/exec.js
+++ b/src/exec.js
@@ -1,16 +1,12 @@
 import childProcess from 'child_process'
 import stripFinalNewline from 'strip-final-newline'
 
-const TEN_MEBIBYTE = 1024 * 1024 * 10
-
-const exec = (command, args, stdin) => {
+const exec = (command, args, stdin, spawnOptions) => {
   return new Promise((resolve, reject) => {
     var stdout = ''
     var stderr = ''
 
-    const process = childProcess.spawn(command, args, {
-      maxBuffer: TEN_MEBIBYTE
-    })
+    const process = childProcess.spawn(command, args, spawnOptions)
 
     if (stdin) {
       process.stdin.setEncoding('utf-8')

--- a/src/jq.d.ts
+++ b/src/jq.d.ts
@@ -1,11 +1,3 @@
-import * as childProcess from "child_process";
 import { PartialOptions } from "./options"
 
-interface run {
-    (filter: string, json: any, options?: PartialOptions, jqPath?: string, spawnOptions?: childProcess.SpawnOptions): Promise<object | string>
-}
-export class JQ {
-    constructor(jqPath?: string, spawnOptions?: childProcess.SpawnOptions);
-    run: run;
-}
-export const run: run;
+export function run(filter: string, json: any, options?: PartialOptions, jqPath?: string, cwd?: string): Promise<object | string>

--- a/src/jq.d.ts
+++ b/src/jq.d.ts
@@ -1,0 +1,11 @@
+import * as childProcess from "child_process";
+import { PartialOptions } from "./options"
+
+interface run {
+    (filter: string, json: any, options?: PartialOptions, jqPath?: string, spawnOptions?: childProcess.SpawnOptions): Promise<object | string>
+}
+export class JQ {
+    constructor(jqPath?: string, spawnOptions?: childProcess.SpawnOptions);
+    run: run;
+}
+export const run: run;

--- a/src/jq.js
+++ b/src/jq.js
@@ -1,12 +1,10 @@
 import exec from './exec'
 import { commandFactory } from './command'
 
-const TEN_MEBIBYTE = 1024 * 1024 * 10
-
-export const run = (filter, json, options = {}, jqPath, spawnOptions = { maxBuffer: TEN_MEBIBYTE }) => {
+export const run = (filter, json, options = {}, jqPath, cwd) => {
   return new Promise((resolve, reject) => {
     const { command, args, stdin } = commandFactory(filter, json, options, jqPath)
-    exec(command, args, stdin, spawnOptions)
+    exec(command, args, stdin, cwd)
       .then(stdout => {
         if (options.output === 'json') {
           let result
@@ -22,15 +20,4 @@ export const run = (filter, json, options = {}, jqPath, spawnOptions = { maxBuff
       })
       .catch(reject)
   })
-}
-
-export class JQ {
-  constructor (jqPath, spawnOptions) {
-    this.jqPath = jqPath
-    this.spawnOptions = spawnOptions
-  }
-
-  run (filter, json, options) {
-    return run(filter, json, options, this.jqPath, this.spawnOptions)
-  }
 }

--- a/src/jq.js
+++ b/src/jq.js
@@ -1,10 +1,12 @@
 import exec from './exec'
 import { commandFactory } from './command'
 
-export const run = (filter, json, options = {}) => {
+const TEN_MEBIBYTE = 1024 * 1024 * 10
+
+export const run = (filter, json, options = {}, jqPath, spawnOptions = { maxBuffer: TEN_MEBIBYTE }) => {
   return new Promise((resolve, reject) => {
-    const { command, args, stdin } = commandFactory(filter, json, options)
-    exec(command, args, stdin)
+    const { command, args, stdin } = commandFactory(filter, json, options, jqPath)
+    exec(command, args, stdin, spawnOptions)
       .then(stdout => {
         if (options.output === 'json') {
           let result
@@ -20,4 +22,15 @@ export const run = (filter, json, options = {}) => {
       })
       .catch(reject)
   })
+}
+
+export class JQ {
+  constructor (jqPath, spawnOptions) {
+    this.jqPath = jqPath
+    this.spawnOptions = spawnOptions
+  }
+
+  run (filter, json, options) {
+    return run(filter, json, options, this.jqPath, this.spawnOptions)
+  }
 }

--- a/src/options.d.ts
+++ b/src/options.d.ts
@@ -1,0 +1,16 @@
+import * as Joi from "@hapi/joi";
+
+export const optionsSchema: Joi.SchemaLike
+export const preSpawnSchema: Joi.SchemaLike
+export const spawnSchema: Joi.SchemaLike
+export function parseOptions(options: PartialOptions, filter: string, json: any): any
+export const optionDefaults: IOptions;
+interface IOptions {
+    color: boolean,
+    locations: string[],
+    output: string,
+    raw: boolean,
+    slurp: boolean,
+    sort: boolean,
+}
+export type PartialOptions = Partial<IOptions>

--- a/src/options.js
+++ b/src/options.js
@@ -1,14 +1,6 @@
 import * as Joi from '@hapi/joi'
 import { validateJSONPath } from './utils'
 
-export const optionDefaults = {
-  input: 'file',
-  output: 'pretty',
-  slurp: false,
-  sort: false,
-  raw: false
-}
-
 function createBooleanSchema (name, value) {
   return Joi.string().when(`${name}`, {
     is: Joi.boolean().required().valid(true),
@@ -20,7 +12,8 @@ const strictBoolean = Joi.boolean().default(false).strict()
 const path = Joi.any()
   .custom((value, helpers) => {
     try {
-      return validateJSONPath(value) ? value : helpers.error('any.invalid')
+      validateJSONPath(value)
+      return value
     } catch (e) {
       const errorType = e.message.includes('.json') ? 'json' : 'path'
       return helpers.error('any.invalid', { type: errorType })
@@ -101,3 +94,5 @@ export const parseOptions = (options = {}, filter, json) => {
   }
   return Object.values(validatedSpawn.args).concat(filter)
 }
+
+export const optionDefaults = Joi.attempt({}, optionsSchema)

--- a/src/options.js
+++ b/src/options.js
@@ -1,3 +1,6 @@
+import * as Joi from '@hapi/joi'
+import { validateJSONPath } from './utils'
+
 export const optionDefaults = {
   input: 'file',
   output: 'pretty',
@@ -6,49 +9,95 @@ export const optionDefaults = {
   raw: false
 }
 
-const optionMap = {
-  output: {
-    buildParams: (params, value) => {
-      if (value === 'string' || value === 'compact') {
-        params.unshift('--compact-output')
-      }
-    }
-  },
-  slurp: {
-    buildParams: (params, value) => {
-      if (value === true) {
-        params.unshift('--slurp')
-      }
-    }
-  },
-  sort: {
-    buildParams: (params, value) => {
-      if (value === true) {
-        params.unshift('--sort-keys')
-      }
-    }
-  },
-  color: {
-    buildParams: (params, value) => {
-      if (value === true) {
-        params.unshift('--color-output')
-      }
-    }
-  },
-  raw: {
-    buildParams: (params, value) => {
-      if (value === true) {
-        params.unshift('-r')
-      }
-    }
-  }
+function createBooleanSchema (name, value) {
+  return Joi.string().when(`${name}`, {
+    is: Joi.boolean().required().valid(true),
+    then: Joi.string().default(value)
+  })
 }
 
-export const parseOptions = (options = {}) => {
-  return Object.keys(options).reduce((params, key, index) => {
-    if (optionMap[key] !== undefined) {
-      optionMap[key].buildParams(params, options[key])
+const strictBoolean = Joi.boolean().default(false).strict()
+const path = Joi.any()
+  .custom((value, helpers) => {
+    try {
+      return validateJSONPath(value) ? value : helpers.error('any.invalid')
+    } catch (e) {
+      const errorType = e.message.includes('.json') ? 'json' : 'path'
+      return helpers.error('any.invalid', { type: errorType })
     }
-    return params
-  }, [])
+  }, 'path validation').required().error((errors) => {
+    errors.forEach(error => {
+      if (error.value === undefined) {
+        error.local.type = 'path'
+      }
+    })
+    return errors
+  })
+
+export const optionsSchema = Joi.object({
+  color: strictBoolean,
+  input: Joi.string().default('file').valid('file', 'json', 'string'),
+  locations: Joi.array().items(Joi.string()).default([]),
+  output: Joi.string().default('pretty').valid('string', 'compact', 'pretty', 'json'),
+  raw: strictBoolean,
+  slurp: strictBoolean,
+  sort: strictBoolean
+})
+
+export const preSpawnSchema = Joi.object({
+  filter: Joi.string().allow('', null).required(),
+  json: Joi.any().alter({
+    file: (schema) => {
+      return schema.when('/json',
+        {
+          is: Joi.array().required(),
+          then: Joi.array().items(path),
+          otherwise: path
+        }).label('path')
+    },
+    json: (schema) => Joi.object().allow('', null).required().label('json object'),
+    string: (schema) => Joi.string().required().label('json string')
+  })
+})
+
+export const spawnSchema = Joi.object({
+  args: Joi.object({
+    color: createBooleanSchema('$options.color', '--color-output'),
+    input: Joi.any().alter({
+      file: (schema) => schema.when('$json', {
+        is: [Joi.array().items(Joi.string()), Joi.string()],
+        then: Joi.array().default(Joi.ref('$json', {
+          adjust: (value) => {
+            return [].concat(value)
+          }
+        }))
+      })
+    }),
+    locations: Joi.ref('$options.locations'),
+    output: Joi.string().when('$options.output', {
+      is: Joi.string().required().valid('string', 'compact'),
+      then: Joi.string().default('--compact-output')
+    }),
+    raw: createBooleanSchema('$options.raw', '-r'),
+    slurp: createBooleanSchema('$options.slurp', '--slurp'),
+    sort: createBooleanSchema('$options.sort', '--sort-keys')
+  }).default(),
+  stdin: Joi.string().default('').alter({
+    json: (schema) => schema.default(Joi.ref('$json', {
+      adjust: (value) => JSON.stringify(value)
+    })),
+    string: (schema) => schema.default(Joi.ref('$json'))
+  })
+})
+
+export const parseOptions = (options = {}, filter, json) => {
+  const context = { filter, json, options }
+  const validatedSpawn = Joi.attempt({}, spawnSchema.tailor(options.input), { context })
+
+  if (options.input === 'file') {
+    return Object.keys(validatedSpawn.args).filter((key) => key !== 'input')
+      .reduce((list, key) => list.concat(validatedSpawn.args[key]), [])
+      .concat(filter, json)
+  }
+  return Object.values(validatedSpawn.args).concat(filter)
 }

--- a/src/utils.d.ts
+++ b/src/utils.d.ts
@@ -1,0 +1,8 @@
+export const INVALID_PATH_ERROR =
+    'node-jq: invalid path argument supplied (not a valid path)'
+export const INVALID_JSON_PATH_ERROR =
+    'node-jq: invalid path argument supplied (not a .json file)'
+
+export function isJSONPath(path: any): boolean
+
+export function validateJSONPath(path: any): boolean

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,4 +17,6 @@ export const validateJSONPath = path => {
   if (!isJSONPath(path)) {
     throw new Error(`${INVALID_JSON_PATH_ERROR}: "${path === '' ? '' : path}"`)
   }
+
+  return true
 }

--- a/test/command.test.js
+++ b/test/command.test.js
@@ -1,0 +1,46 @@
+import { expect } from 'chai'
+import path from 'path'
+
+import { commandFactory } from '../src/command'
+import { FILTER_UNDEFINED_ERROR } from '../src/command'
+import { INVALID_PATH_ERROR, INVALID_JSON_PATH_ERROR } from '../src/utils'
+
+const PATH_ROOT = path.join(__dirname, '..')
+const PATH_ASTERISK_FIXTURE = path.join(PATH_ROOT, 'src', '*.js')
+const PATH_FIXTURES = path.join('test', 'fixtures')
+
+const PATH_JSON_FIXTURE = path.join(PATH_FIXTURES, '1.json')
+const PATH_JS_FIXTURE = path.join(PATH_FIXTURES, '1.js')
+const PATH_LARGE_JSON_FIXTURE = path.join(PATH_FIXTURES, 'large.json')
+const PATH_VARIABLE_JSON_FIXTURE = path.join(PATH_FIXTURES, 'var.json')
+
+const FIXTURE_JSON = require('./fixtures/1.json')
+const FIXTURE_JSON_STRING = JSON.stringify(FIXTURE_JSON, null, 2)
+
+const FILTER_VALID = '.repository.type'
+const FILTER_INVALID = 'invalid'
+const FILTER_WITH_VARIABLE =
+    '[ . as $x | .user[] | {"user": ., "site": $x.site} ]'
+
+const ERROR_INVALID_FILTER = /invalid/
+
+const EMPTY_OPTION_RESULT = {
+    command: path.join(__dirname, '../bin/jq'),
+    args: [
+        FILTER_VALID,
+        PATH_JSON_FIXTURE
+    ],
+    stdin: ''
+}
+
+describe('command', () => {
+    it('factory should accept undefined options', done => {
+        try {
+            const result = commandFactory(FILTER_VALID, PATH_JSON_FIXTURE)
+            expect(result).to.deep.equal(EMPTY_OPTION_RESULT)
+      done()
+        } catch (e) {
+            done(e)
+        }
+    })
+})

--- a/test/command.test.js
+++ b/test/command.test.js
@@ -2,45 +2,29 @@ import { expect } from 'chai'
 import path from 'path'
 
 import { commandFactory } from '../src/command'
-import { FILTER_UNDEFINED_ERROR } from '../src/command'
-import { INVALID_PATH_ERROR, INVALID_JSON_PATH_ERROR } from '../src/utils'
 
-const PATH_ROOT = path.join(__dirname, '..')
-const PATH_ASTERISK_FIXTURE = path.join(PATH_ROOT, 'src', '*.js')
 const PATH_FIXTURES = path.join('test', 'fixtures')
-
 const PATH_JSON_FIXTURE = path.join(PATH_FIXTURES, '1.json')
-const PATH_JS_FIXTURE = path.join(PATH_FIXTURES, '1.js')
-const PATH_LARGE_JSON_FIXTURE = path.join(PATH_FIXTURES, 'large.json')
-const PATH_VARIABLE_JSON_FIXTURE = path.join(PATH_FIXTURES, 'var.json')
-
-const FIXTURE_JSON = require('./fixtures/1.json')
-const FIXTURE_JSON_STRING = JSON.stringify(FIXTURE_JSON, null, 2)
 
 const FILTER_VALID = '.repository.type'
-const FILTER_INVALID = 'invalid'
-const FILTER_WITH_VARIABLE =
-    '[ . as $x | .user[] | {"user": ., "site": $x.site} ]'
-
-const ERROR_INVALID_FILTER = /invalid/
 
 const EMPTY_OPTION_RESULT = {
-    command: path.join(__dirname, '../bin/jq'),
-    args: [
-        FILTER_VALID,
-        PATH_JSON_FIXTURE
-    ],
-    stdin: ''
+  command: path.join(__dirname, '../bin/jq'),
+  args: [
+    FILTER_VALID,
+    PATH_JSON_FIXTURE
+  ],
+  stdin: ''
 }
 
 describe('command', () => {
-    it('factory should accept undefined options', done => {
-        try {
-            const result = commandFactory(FILTER_VALID, PATH_JSON_FIXTURE)
-            expect(result).to.deep.equal(EMPTY_OPTION_RESULT)
+  it('factory should accept undefined options', done => {
+    try {
+      const result = commandFactory(FILTER_VALID, PATH_JSON_FIXTURE)
+      expect(result).to.deep.equal(EMPTY_OPTION_RESULT)
       done()
-        } catch (e) {
-            done(e)
-        }
-    })
+    } catch (e) {
+      done(e)
+    }
+  })
 })

--- a/test/jq.test.js
+++ b/test/jq.test.js
@@ -1,11 +1,12 @@
 import { expect } from 'chai'
 import path from 'path'
 
-import { run } from '../src/jq'
+import { run, JQ } from '../src/jq'
 import { FILTER_UNDEFINED_ERROR } from '../src/command'
 import { INVALID_PATH_ERROR, INVALID_JSON_PATH_ERROR } from '../src/utils'
 
 const PATH_ROOT = path.join(__dirname, '..')
+const PATH_BIN = path.join(PATH_ROOT, './bin')
 const PATH_ASTERISK_FIXTURE = path.join(PATH_ROOT, 'src', '*.js')
 const PATH_FIXTURES = path.join('test', 'fixtures')
 
@@ -23,6 +24,9 @@ const FILTER_WITH_VARIABLE =
   '[ . as $x | .user[] | {"user": ., "site": $x.site} ]'
 
 const ERROR_INVALID_FILTER = /invalid/
+
+const TEN_MEBIBYTE = 1024 * 1024 * 10
+const SPAWN_OPTIONS = { maxBuffer: TEN_MEBIBYTE }
 
 describe('jq core', () => {
   it('should fulfill its promise', done => {
@@ -126,6 +130,52 @@ describe('jq core', () => {
     run('.', PATH_LARGE_JSON_FIXTURE)
       .then(output => {
         expect(output).to.be.a('string')
+        done()
+      })
+      .catch(error => {
+        done(error)
+      })
+  })
+
+  it('should allow running from class instance', done => {
+    new JQ().run(FILTER_VALID, PATH_JSON_FIXTURE)
+      .then(output => {
+        expect(output).to.equal('"git"')
+        done()
+      })
+      .catch(error => {
+        done(error)
+      })
+  })
+
+  it('should allow custom jqPath from function argument', done => {
+    run(FILTER_VALID, PATH_JSON_FIXTURE, undefined, PATH_BIN)
+      .then(output => {
+        expect(output).to.equal('"git"')
+        done()
+      })
+      .catch(error => {
+        done(error)
+      })
+  })
+
+  it('should allow custom jqPath from env', done => {
+    process.env.JQ_PATH = PATH_BIN
+    run(FILTER_VALID, PATH_JSON_FIXTURE)
+      .then(output => {
+        expect(output).to.equal('"git"')
+        done()
+      })
+      .catch(error => {
+        done(error)
+      })
+    process.env.JQ_PATH = undefined
+  })
+
+  it('should allow custom spawnOptions', done => {
+    run(FILTER_VALID, PATH_JSON_FIXTURE, undefined, undefined, SPAWN_OPTIONS)
+      .then(output => {
+        expect(output).to.equal('"git"')
         done()
       })
       .catch(error => {

--- a/test/jq.test.js
+++ b/test/jq.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import path from 'path'
 
-import { run, JQ } from '../src/jq'
+import { run } from '../src/jq'
 import { FILTER_UNDEFINED_ERROR } from '../src/command'
 import { INVALID_PATH_ERROR, INVALID_JSON_PATH_ERROR } from '../src/utils'
 
@@ -25,8 +25,7 @@ const FILTER_WITH_VARIABLE =
 
 const ERROR_INVALID_FILTER = /invalid/
 
-const TEN_MEBIBYTE = 1024 * 1024 * 10
-const SPAWN_OPTIONS = { maxBuffer: TEN_MEBIBYTE }
+const CWD_OPTION = path.join(PATH_BIN, '../')
 
 describe('jq core', () => {
   it('should fulfill its promise', done => {
@@ -137,17 +136,6 @@ describe('jq core', () => {
       })
   })
 
-  it('should allow running from class instance', done => {
-    new JQ().run(FILTER_VALID, PATH_JSON_FIXTURE)
-      .then(output => {
-        expect(output).to.equal('"git"')
-        done()
-      })
-      .catch(error => {
-        done(error)
-      })
-  })
-
   it('should allow custom jqPath from function argument', done => {
     run(FILTER_VALID, PATH_JSON_FIXTURE, undefined, PATH_BIN)
       .then(output => {
@@ -172,8 +160,8 @@ describe('jq core', () => {
     process.env.JQ_PATH = undefined
   })
 
-  it('should allow custom spawnOptions', done => {
-    run(FILTER_VALID, PATH_JSON_FIXTURE, undefined, undefined, SPAWN_OPTIONS)
+  it('should allow custom cwd', done => {
+    run(FILTER_VALID, PATH_JSON_FIXTURE, undefined, undefined, CWD_OPTION)
       .then(output => {
         expect(output).to.equal('"git"')
         done()

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai'
 import path from 'path'
 
 import { run } from '../src/jq'
-import { optionDefaults } from '../src/options'
+import { optionDefaults, parseOptions } from '../src/options'
 import { INPUT_JSON_UNDEFINED_ERROR, INPUT_STRING_ERROR } from '../src/command'
 import { INVALID_PATH_ERROR, INVALID_JSON_PATH_ERROR } from '../src/utils'
 
@@ -16,17 +16,33 @@ const FIXTURE_JSON = require('./fixtures/1.json')
 const FIXTURE_JSON_STRING = JSON.stringify(FIXTURE_JSON)
 const FIXTURE_JSON_PRETTY = JSON.stringify(FIXTURE_JSON, null, 2)
 
+const FILTER_VALID = '.repository.type'
+
 const OPTION_DEFAULTS = {
   input: 'file',
   output: 'pretty',
   slurp: false,
   sort: false,
-  raw: false
+  raw: false,
+  locations: [],
+  color: false
 }
 
 const multiEOL = text => {
   return [text, text.replace(/\n/g, '\r\n')]
 }
+
+describe('parse options', () => {
+  it('should work with undefined options', done => {
+    try {
+      const result = parseOptions(undefined, FILTER_VALID, FIXTURE_JSON)
+      expect(result).to.deep.equal([FILTER_VALID])
+      done()
+    } catch (e) {
+      done(e)
+    }
+  })
+})
 
 describe('options', () => {
   it('defaults should be as expected', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -667,6 +667,44 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@hapi/address@2.x.x":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.0.0.tgz#9f05469c88cb2fd3dcd624776b54ee95c312126a"
+  integrity sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==
+
+"@hapi/formula@1.x.x":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@hapi/formula/-/formula-1.2.0.tgz#994649c7fea1a90b91a0a1e6d983523f680e10cd"
+  integrity sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA==
+
+"@hapi/hoek@8.x.x":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.2.0.tgz#079a133be240ff866ad8532eaa46a691bdd91117"
+  integrity sha512-pR2ZgiP562aiaQvQ98WgfqfTrm+xG+7hwHRPEiYZ+7U1OHAAb4OVZJIalCP03bMqYSioQzflzVTVrybSwDBn1Q==
+
+"@hapi/joi@16.0.0-preview":
+  version "16.0.0-preview"
+  resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-16.0.0-preview.tgz#49cacd3e06865e24df48c6d8e17149d5a49a727d"
+  integrity sha512-Z3ue0n3AwSKCuE7HVVTXc+vaC+YaJwT4wks6ZbS1hXjzAn/nzSHrO9qUGDhrfC3ytE6Rd+kn255AntBw2dKZWg==
+  dependencies:
+    "@hapi/address" "2.x.x"
+    "@hapi/formula" "1.x.x"
+    "@hapi/hoek" "8.x.x"
+    "@hapi/marker" "1.x.x"
+    "@hapi/topo" "3.x.x"
+
+"@hapi/marker@1.x.x":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/marker/-/marker-1.0.0.tgz#65b0b2b01d1be06304886ce9b4b77b1bfb21a769"
+  integrity sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA==
+
+"@hapi/topo@3.x.x":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-3.1.3.tgz#c7a02e0d936596d29f184e6d7fdc07e8b5efce11"
+  integrity sha512-JmS9/vQK6dcUYn7wc2YZTqzIKubAQcJKu2KCKAru6es482U5RT5fP1EXCPtlXpiK7PR0On/kpQKI4fRKkzpZBQ==
+  dependencies:
+    "@hapi/hoek" "8.x.x"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"

--- a/yarn.lock
+++ b/yarn.lock
@@ -843,6 +843,13 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@types/hapi__joi@*", "@types/hapi__joi@^15.0.3":
+  version "15.0.3"
+  resolved "https://registry.yarnpkg.com/@types/hapi__joi/-/hapi__joi-15.0.3.tgz#eeeca99e3829636975bf39532d6e8279409c78f2"
+  integrity sha512-kncvQstpAQSjQ+J+tL2oYerjOEepv+yJHKM/JD/NmFZyDcy3rYOBcMJhdHRDjBxuSZu3ipGECszhgtmug9VSuw==
+  dependencies:
+    "@types/hapi__joi" "*"
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"


### PR DESCRIPTION
As requested a more modest update that adheres to existing exports. 

- swaps out builder system for Joi
- unifies filter, json, and option validation
- adds a JQ class that accepts a custom jqPath and SpawnOptions
- existing functions updated to accept custom jqPath and SpawnOptions
- typescript definition files for each js created
- support for locations and color options
- 100% code coverage