### PR TITLE
fix: Add process.stdout.setEncoding

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -18,6 +18,7 @@ const exec = (command, args, stdin, cwd) => {
       process.stdin.end()
     }
 
+    process.stdout.setEncoding('utf-8');
     process.stdout.on('data', data => {
       stdout += data
     })

--- a/src/exec.js
+++ b/src/exec.js
@@ -18,7 +18,7 @@ const exec = (command, args, stdin, cwd) => {
       process.stdin.end()
     }
 
-    process.stdout.setEncoding('utf-8');
+    process.stdout.setEncoding('utf-8')
     process.stdout.on('data', data => {
       stdout += data
     })


### PR DESCRIPTION
I added `process.stdio.setEncoding('utf-8')` to exec.js.
This is because without this code, the output containing multibyte characters will be garbled.