### PR TITLE
Add binaries for linux into download map

### DIFF
--- a/scripts/install-binary.js
+++ b/scripts/install-binary.js
@@ -53,6 +53,10 @@ const DOWNLOAD_MAP = {
   darwin: {
     def: 'jq-osx-amd64',
     x64: 'jq-osx-amd64'
+  },
+  linux: {
+    def: 'jq-linux32',
+    x64: 'jq-linux64'
   }
 }
 


### PR DESCRIPTION
Add Linux binaries to the download map so we don't need to compile from scratch.