### PR TITLE
Add `read` permission to the downloaded `jq` binary

### DIFF
--- a/scripts/install-binary.js
+++ b/scripts/install-binary.js
@@ -79,6 +79,7 @@ if (platform in DOWNLOAD_MAP) {
         // fs.chmodSync(distPath, fs.constants.S_IXUSR || 0o100)
         // Huan(202111): we need the read permission so that the build system can pack the node_modules/ folder,
         // i.e. build with Heroku CI/CD, docker build, etc.
+        // @see https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html
         fs.chmodSync(distPath,
           fs.constants.S_IXUSR | fs.constants.S_IREAD | fs.constants.S_IROTH | fs.constants.S_IRGRP 
           || 0o100 | 0o400 | 0o040 | 0o004)

--- a/scripts/install-binary.js
+++ b/scripts/install-binary.js
@@ -81,8 +81,8 @@ if (platform in DOWNLOAD_MAP) {
         // i.e. build with Heroku CI/CD, docker build, etc.
         // @see https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html
         fs.chmodSync(distPath,
-          fs.constants.S_IXUSR | fs.constants.S_IREAD | fs.constants.S_IROTH | fs.constants.S_IRGRP 
-          || 0o100 | 0o400 | 0o040 | 0o004)
+          (fs.constants.S_IXUSR | fs.constants.S_IREAD | fs.constants.S_IROTH | fs.constants.S_IRGRP) ||
+          0o100 | 0o400 | 0o040 | 0o004)
       }
       console.log(`Downloaded in ${OUTPUT_DIR}`)
     })

--- a/scripts/install-binary.js
+++ b/scripts/install-binary.js
@@ -76,7 +76,12 @@ if (platform in DOWNLOAD_MAP) {
       const distPath = path.join(OUTPUT_DIR, JQ_NAME)
       fs.renameSync(path.join(OUTPUT_DIR, filename), distPath)
       if (fileExist(distPath)) {
-        fs.chmodSync(distPath, fs.constants.S_IXUSR || 0o100)
+        // fs.chmodSync(distPath, fs.constants.S_IXUSR || 0o100)
+        // Huan(202111): we need the read permission so that the build system can pack the node_modules/ folder,
+        // i.e. build with Heroku CI/CD, docker build, etc.
+        fs.chmodSync(distPath,
+          fs.constants.S_IXUSR | fs.constants.S_IREAD | fs.constants.S_IROTH | fs.constants.S_IRGRP 
+          || 0o100 | 0o400 | 0o040 | 0o004)
       }
       console.log(`Downloaded in ${OUTPUT_DIR}`)
     })


### PR DESCRIPTION
We need the read permission so that the build system can pack the `node_modules/` folder.

i.e. build with Heroku CI/CD, docker build, etc.