### PR TITLE
use `chmod 0755`

### DIFF
--- a/scripts/install-binary.js
+++ b/scripts/install-binary.js
@@ -79,10 +79,7 @@ if (platform in DOWNLOAD_MAP) {
         // fs.chmodSync(distPath, fs.constants.S_IXUSR || 0o100)
         // Huan(202111): we need the read permission so that the build system can pack the node_modules/ folder,
         // i.e. build with Heroku CI/CD, docker build, etc.
-        // @see https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html
-        fs.chmodSync(distPath,
-          (fs.constants.S_IXUSR | fs.constants.S_IREAD | fs.constants.S_IROTH | fs.constants.S_IRGRP) ||
-          0o100 | 0o400 | 0o040 | 0o004)
+        fs.chmodSync(distPath, 0o755)
       }
       console.log(`Downloaded in ${OUTPUT_DIR}`)
     })


### PR DESCRIPTION
Continue:

- #437 

After testing the published version, I found that the permission number is not right.

I suggest that we can just use `0755` which is `-rwxr-xr-x`

```sh
$ chmod 0755 bin/jq
$ ls -l bin/
total 3864
-rwxr-xr-x 1 huan huan 3953824 Nov 15 23:59 jq
```

## Numbers (incorrect)

```ts
// fs.constants.S_IXUSR 64
// fs.constants.S_IROTH 4
// fs.constants.S_IRGRP 32
// fs.constants.S_IREAD undefined

console.info(fs.constants.S_IXUSR | fs.constants.S_IREAD | fs.constants.S_IROTH | fs.constants.S_IRGRP)
// 100 (0144)

console.info(0o100 | 0o400 | 0o040 | 0o004)
// 0544
```