### PR TITLE
fix: Set up listeners first, in case of long write to stdin.

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -12,11 +12,16 @@ const exec = (command, args, stdin, cwd) => {
 
     const process = childProcess.spawn(command, args, spawnOptions)
 
-    // Both the 'error' and 'close' handlers can close the Promise, so guard
-    // against them both closing it.
+    // All of these handlers can close the Promise, so guard closing it twice.
     let promiseIsClosed = false
 
     process.on('error', err => {
+      if (!promiseIsClosed) {
+        promiseIsClosed = true
+        return reject(err)
+      }
+    })
+    process.stdin.on('error', err => {
       if (!promiseIsClosed) {
         promiseIsClosed = true
         return reject(err)

--- a/src/exec.js
+++ b/src/exec.js
@@ -14,14 +14,6 @@ const exec = (command, args, stdin, cwd) => {
 
     // All of these handlers can close the Promise, so guard against rejecting it twice.
     let promiseAlreadyRejected = false
-    if (stdin) {
-      process.stdin.on('error', err => {
-        if (!promiseAlreadyRejected) {
-          promiseAlreadyRejected = true
-          return reject(err)
-        }
-      })
-    }
     process.on('close', code => {
       if (!promiseAlreadyRejected) {
         promiseAlreadyRejected = true
@@ -34,6 +26,12 @@ const exec = (command, args, stdin, cwd) => {
     })
 
     if (stdin) {
+      process.stdin.on('error', err => {
+        if (!promiseAlreadyRejected) {
+          promiseAlreadyRejected = true
+          return reject(err)
+        }
+      })
       process.stdin.setEncoding('utf-8')
       process.stdin.write(stdin)
       process.stdin.end()


### PR DESCRIPTION
We discovered a bug where large payloads can cause unhandled errors. This is a fix for that bug.

# Root cause of bug

In the `exec` method defined in `src/exec.js`, the child process is spawned, then the JSON data is sent to stdin, and then listeners are added. The problem here is that the child process can exit while we are still writing to its stdin. If this happens, its stdin will also close, and will generate a low-level `EPIPE` error event, as we will be writing to a closed pipe. Nothing will handle that error event.

```javascript
const process = childProcess.spawn(command, args, spawnOptions)

if (stdin) {
  process.stdin.setEncoding('utf-8')
  process.stdin.write(stdin) // <- This line can take a while to complete, during which the child process can exit.
  process.stdin.end()
}
// ... other listeners
process.on('close', code => {
  // ... further code
```

# Steps to reproduce

The following code should reproduce the bug:

```javascript

const jq = require('node-jq');

const generateRandomString = (n) => {
  var result = "";
  var characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
  for (var i = 0; i < n; i++) {
    result += characters.charAt(Math.floor(Math.random() * characters.length));
  }
  return result;
}

async function demo() {
  // The big JSON payload is key, as it will take a long time to write to stdin.
  // Depending on the speed of your machine, you may need to increase its size further in order to trigger the bug.
  var bigPayload = { attribute: generateRandomString(10000) };
  try {
    // "Hello world" is an invalid filter, and will cause jq to exit early (without waiting for stdin)
    await Jq.run("Hello world!", bigPayload, { input: "json" })
  } catch (e) {
    console.log(`Successfully caught jq error: \n----------\n${e}`);
  }
}

demo();
```

### Expected result:

With a big enough payload, we should get and catch the EPIPE:
```
Successfully caught jq error:
----------
Error: write EPIPE
```

### Actual result:

But without the bugfix, you get this:
```
node:events:491
      throw er; // Unhandled 'error' event
      ^

Error: write EPIPE
    at WriteWrap.onWriteComplete [as oncomplete] (node:internal/stream_base_commons:94:16)
Emitted 'error' event on Socket instance at:
    at emitErrorNT (node:internal/streams/destroy:157:8)
    at emitErrorCloseNT (node:internal/streams/destroy:122:3)
    at processTicksAndRejections (node:internal/process/task_queues:83:21) {
  errno: -32,
  code: 'EPIPE',
  syscall: 'write'
}
```

### Notes
With a smaller payload, the bug is not triggered, and we see this:
```
Caught error: Error: jq: error: syntax error, unexpected IDENT, expecting $end (Unix shell quoting issues?) at <top-level>, line 1:
Hello world!
jq: 1 compile error
```

##

# Node versioning note

On older versions of Node, this sort of unhandled error event may have been ignored. On Node v16, it will crash the application.
