### PR TITLE
stop sending process.env into jq execution

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -8,7 +8,7 @@ const exec = (command, args, stdin, cwd) => {
     let stdout = ''
     let stderr = ''
 
-    const spawnOptions = { maxBuffer: TEN_MEBIBYTE, cwd }
+    const spawnOptions = { maxBuffer: TEN_MEBIBYTE, cwd, env: {} }
 
     const process = childProcess.spawn(command, args, spawnOptions)
 

--- a/src/options.test.js
+++ b/src/options.test.js
@@ -378,6 +378,25 @@ describe('options', () => {
     })
   })
 
+  describe('inherited env var', () => {
+    it('process.env should not be sent in to jq execution', done => {
+      process.env.X_TEST_ENV_VAR = 'TEST_VALUE'
+      run('$ENV', PATH_JSON_FIXTURE, {
+        output: 'string'
+      })
+        .then(output => {
+          expect(output).to.be.a('string')
+          expect(output).to.not.contain('X_TEST_ENV_VAR')
+          done()
+        })
+        .catch(error => {
+          done(error)
+        }).finally(() => {
+          delete process.env.X_TEST_ENV_VAR
+        })
+    })
+  })
+
   describe('raw: true', () => {
     it('output should be able to output raw strings instead of JSON texts', done => {
       run('.name', PATH_JSON_FIXTURE, {


### PR DESCRIPTION
This pr stops implicitly sending the current execution env into the JQ execution (which can be read with "$ENV" in the jq filter).

I added a test that demonstrates the issue, if you back the change to src/exec.js out, you'll see that the entire collection of environment variables will get reflected in the output object.