### PR TITLE
Remove support for Node v10, test Node v18 and v20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Generate code coverage
         if: success() && github.ref == 'refs/heads/main' && ${{ runner.os }} == 'ubuntu-latest' && 16 == ${{ runner.node-version }}
-        uses: paambaati/codeclimate-action@v3.0.0
+        uses: paambaati/codeclimate-action@v5.0.0
         env:
           CC_TEST_REPORTER_ID: b4ef7769e0f8f04456e8e1168b4beb44561bd5ce9ca216458a164e19c4cf7308
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node-version:
-          - 10
           - 12
           - 16
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Use Node ${{ runner.node-version }}
+      - name: Use Node ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ runner.node-version }}
+          node-version: ${{ matrix.node-version }}
 
       - uses: actions/cache@v2
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ matrix.os }}-modules-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install
         run: npm install --prefer-offline
@@ -49,7 +49,7 @@ jobs:
         run: npm run test
 
       - name: Generate code coverage
-        if: success() && github.ref == 'refs/heads/main' && ${{ runner.os }} == 'ubuntu-latest' && 16 == ${{ runner.node-version }}
+        if: success() && github.ref == 'refs/heads/main' && ${{ matrix.os }} == 'ubuntu-latest' && 16 == ${{ matrix.node-version }}
         uses: paambaati/codeclimate-action@v5.0.0
         env:
           CC_TEST_REPORTER_ID: b4ef7769e0f8f04456e8e1168b4beb44561bd5ce9ca216458a164e19c4cf7308
@@ -58,7 +58,7 @@ jobs:
           debug: true
 
       - name: Semantic Release
-        if: success() && github.ref == 'refs/heads/main' && ${{ runner.os }} == 'ubuntu-latest' && 16 == ${{ runner.node-version }}
+        if: success() && github.ref == 'refs/heads/main' && ${{ matrix.os }} == 'ubuntu-latest' && 16 == ${{ matrix.node-version }}
         uses: cycjimmy/semantic-release-action@v3
         with:
           branches: "main"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         node-version:
           - 12
           - 16
+          - 18
+          - 20
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node ${{ matrix.node-version }}
         uses: actions/setup-node@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ matrix.os }}-modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ matrix.os }}-modules-
 
       - name: Install
         run: npm install --prefer-offline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,20 +55,20 @@ jobs:
       - name: Test
         run: npm run test
 
-      - name: Generate code coverage
-        if: success() && github.ref == 'refs/heads/main' && ${{ matrix.os }} == 'ubuntu-latest' && 16 == ${{ matrix.node-version }}
-        uses: paambaati/codeclimate-action@v5.0.0
-        env:
-          CC_TEST_REPORTER_ID: b4ef7769e0f8f04456e8e1168b4beb44561bd5ce9ca216458a164e19c4cf7308
-        with:
-          coverageCommand: npm run coverage
-          debug: true
+#       - name: Generate code coverage
+#         if: success() && github.ref == 'refs/heads/main' && ${{ matrix.os }} == 'ubuntu-latest' && 16 == ${{ matrix.node-version }}
+#         uses: paambaati/codeclimate-action@v5.0.0
+#         env:
+#           CC_TEST_REPORTER_ID: b4ef7769e0f8f04456e8e1168b4beb44561bd5ce9ca216458a164e19c4cf7308
+#         with:
+#           coverageCommand: npm run coverage
+#           debug: true
 
       - name: Semantic Release
         if: success() && github.ref == 'refs/heads/main' && ${{ matrix.os }} == 'ubuntu-latest' && 16 == ${{ matrix.node-version }}
         uses: cycjimmy/semantic-release-action@v3
         with:
-          branches: "main"
+          branches: 'main'
           extra_plugins: |
             @semantic-release/changelog
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "validate-commit-msg": "^2.14.0"
       },
       "engines": {
-        "npm": ">=6.0.0"
+        "node": ">=12"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "semantic-release": "semantic-release"
   },
   "engines": {
-    "npm": ">=6.0.0"
+    "node": ">=12"
   },
   "keywords": [
     "jq",


### PR DESCRIPTION
@davesnx We're officially dropping support for Node v10 — though I think we already weren't testing different Node.js versions in the CI test matrix.

An incorrect reference `runner.node-version` was used in the GH Actions workflow, which was undefined. I fixed the reference by renaming it to `matrix.node-version` in https://github.com/sanack/node-jq/pull/606/commits/8d867733e5d632d44dc94849afb357a1984d2746. After that the Node v10 build started failing. See https://github.com/sanack/node-jq/actions/runs/5732042212/job/15534213902

I also disabled the CodeClimate code coverage reporter, since that failed on Windows. Supposedly that was fixed in [v5.0.0](https://github.com/paambaati/codeclimate-action/releases/tag/v5.0.0), but still the build failed. Will come up with a follow-up PR to properly set it up, I'm planning some changes anyway.