### PR TITLE
Add jq bin field to package.json

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -15,13 +15,9 @@
 
 If this is a feature request, explain why it should be added. Specific use-cases are best.
 
-For bug reports, please provide as much *relevant* info as possible and create a minimum reproduction with this [codesandbox](https://codesandbox.io/s/node-jq-issue-playground-4kqhr).
+For bug reports, please provide as much *relevant* info as possible and create a minimum reproduction by using this [playground](https://replit.com/@DavidSancho/try-node-jq?v=1#index.js) template.
 
-### Test Source
-
-```js
-// Avoid posting many lines of source code that aren't related with the issue.
-```
+If a playground is provided there's a much higher chance of your issue being resolved quickly.
 
 ### Error Message & Stack Trace
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "node-jq",
-  "version": "4.1.0-rc.0",
+  "version": "4.1.0-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "4.1.0-rc.0",
+      "version": "4.1.0-rc.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "node-jq",
-  "version": "4.1.0-rc.1",
+  "version": "4.1.0-rc.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "4.1.0-rc.1",
+      "version": "4.1.0-rc.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-jq",
-  "version": "4.1.0-rc.2",
+  "version": "0.0.0-automated-versioning",
   "description": "Run jq in node",
   "main": "lib/jq.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "https://github.com/sanack/node-jq"
   },
+  "bin": {
+    "node-jq": "bin/jq"
+  },
   "scripts": {
     "pretest": "npm run install-binary",
     "install-binary": "node scripts/install-binary.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "url": "https://github.com/sanack/node-jq"
   },
   "bin": {
-    "node-jq": "bin/jq"
+    "node-jq": "bin/jq",
+    "jq": "bin/jq"
   },
   "scripts": {
     "pretest": "npm run install-binary",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-jq",
-  "version": "4.1.0-rc.0",
+  "version": "4.1.0-rc.1",
   "description": "Run jq in node",
   "main": "lib/jq.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-jq",
-  "version": "4.1.0-rc.1",
+  "version": "4.1.0-rc.2",
   "description": "Run jq in node",
   "main": "lib/jq.js",
   "repository": {


### PR DESCRIPTION
Allows `npx node-jq "." package.json` (and `npx jq "." package.json` if you already installed node-jq)

Side note: Includes a chance to the issue_template I had on `main` (mb)
