### PR TITLE
Bump up to jq 1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![https://lima.codeclimate.com/github/sanack/node-jq/coverage](https://lima.codeclimate.com/github/sanack/node-jq/badges/coverage.svg)
 ![https://github.com/sanack/node-jq/actions/workflows/ci.yml](https://github.com/sanack/node-jq/actions/workflows/ci.yml/badge.svg)
 
-[node-jq](https://github.com/sanack/node-jq) is a Node.js wrapper for [jq](https://stedolan.github.io/jq/) - a lightweight and flexible command-line JSON processor
+[node-jq](https://github.com/sanack/node-jq) is a Node.js wrapper for [jq](https://jqlang.github.io/jq/) - a lightweight and flexible command-line JSON processor
 
 ---
 
@@ -20,7 +20,7 @@ $ yarn add node-jq
 
 ## Advanced installation
 
-By default, `node-jq` downloads `jq` during the installation process with a post-install script. Depending on your SO downloads from [https://github.com/stedolan/jq/releases] into `./node_modules/node-jq/bin/jq` to avoid colisions with any global installation. Check #161 #167 #171 for more information. You can safely rely on this location for your installed `jq`, we won't change this path without a major version upgrade.
+By default, `node-jq` downloads `jq` during the installation process with a post-install script. Depending on your SO downloads from [https://github.com/jqlang/jq/releases] into `./node_modules/node-jq/bin/jq` to avoid colisions with any global installation. Check #161 #167 #171 for more information. You can safely rely on this location for your installed `jq`, we won't change this path without a major version upgrade.
 
 If you want to skip the installation step of `jq`, you can set `NODE_JQ_SKIP_INSTALL_BINARY` to `true` or ignore the post-install script from the installation `npm install node-jq --ignore-scripts`.
 
@@ -262,7 +262,7 @@ Seems hard to learn, but it really isn't.
 
 Take a look at [this great introduction](https://robots.thoughtbot.com/jq-is-sed-for-json) or a [jq lesson](http://programminghistorian.org/lessons/json-and-jq).
 
-You can check out the [official manual](https://stedolan.github.io/jq/manual) and fiddle around in the online playground [jqplay.org](https://jqplay.org).
+You can check out the [official manual](https://jqlang.github.io/jq/manual) and fiddle around in the online playground [jqplay.org](https://jqplay.org).
 
 ## License
 

--- a/scripts/install-binary.js
+++ b/scripts/install-binary.js
@@ -31,8 +31,8 @@ const arch = process.arch
 
 const JQ_INFO = {
   name: 'jq',
-  url: 'https://github.com/stedolan/jq/releases/download/',
-  version: 'jq-1.6'
+  url: 'https://github.com/jqlang/jq/releases/download/',
+  version: 'jq-1.7'
 }
 
 const JQ_NAME_MAP = {
@@ -67,30 +67,27 @@ if (process.env.NODE_JQ_SKIP_INSTALL_BINARY === 'true') {
   process.exit(0)
 }
 
-// if platform is missing, download source instead of executable
+// if platform or arch is missing, download source instead of executable
 const DOWNLOAD_MAP = {
   win32: {
-    def: 'jq-win32.exe',
-    x64: 'jq-win64.exe'
+    x64: 'jq-windows-amd64.exe',
+    ia32: 'jq-windows-i386.exe'
   },
   darwin: {
-    def: 'jq-osx-amd64',
-    x64: 'jq-osx-amd64'
+    x64: 'jq-macos-amd64',
+    arm64: 'jq-macos-arm64'
   },
   linux: {
-    def: 'jq-linux32',
-    x64: 'jq-linux64'
+    x64: 'jq-linux-amd64',
+    ia32: 'jq-linux-i386',
+    arm64: 'jq-linux-arm64'
   }
 }
 
-if (platform in DOWNLOAD_MAP) {
+if (platform in DOWNLOAD_MAP && arch in DOWNLOAD_MAP[platform]) {
   // download the executable
 
-  const filename =
-    arch in DOWNLOAD_MAP[platform]
-      ? DOWNLOAD_MAP[platform][arch]
-      : DOWNLOAD_MAP[platform].def
-
+  const filename = DOWNLOAD_MAP[platform][arch]
   const url = `${JQ_INFO.url}${JQ_INFO.version}/${filename}`
 
   console.log(`Downloading jq from ${url}`)
@@ -118,8 +115,7 @@ if (platform in DOWNLOAD_MAP) {
   console.log(`Building jq from ${url}`)
   binBuild
     .url(url, [
-      'autoreconf -fi',
-      `./configure --disable-maintainer-mode --with-oniguruma=builtin --prefix=${tempfile()} --bindir=${OUTPUT_DIR}`,
+      `./configure --with-oniguruma=builtin --prefix=${tempfile()} --bindir=${OUTPUT_DIR}`,
       'make -j8',
       'make install'
     ])

--- a/src/jq.test.js
+++ b/src/jq.test.js
@@ -16,9 +16,6 @@ const PATH_JS_FIXTURE = path.join(PATH_FIXTURES, '1.js')
 const PATH_LARGE_JSON_FIXTURE = path.join(PATH_FIXTURES, 'large.json')
 const PATH_VARIABLE_JSON_FIXTURE = path.join(PATH_FIXTURES, 'var.json')
 
-const FIXTURE_JSON = require('./__test__/fixtures/1.json')
-const FIXTURE_JSON_STRING = JSON.stringify(FIXTURE_JSON, null, 2)
-
 const FILTER_VALID = '.repository.type'
 const FILTER_INVALID = 'invalid'
 const FILTER_WITH_VARIABLE =
@@ -33,18 +30,6 @@ describe('jq core', () => {
     run(FILTER_VALID, PATH_JSON_FIXTURE)
       .then(output => {
         expect(output).to.equal('"git"')
-        done()
-      })
-      .catch(error => {
-        done(error)
-      })
-  })
-
-  it('should pass on an empty filter', done => {
-    run('', PATH_JSON_FIXTURE)
-      .then(output => {
-        const normalizedOutput = output.replace(/\r\n/g, '\n')
-        expect(normalizedOutput).to.equal(FIXTURE_JSON_STRING)
         done()
       })
       .catch(error => {


### PR DESCRIPTION
To follow the new [jq 1.7](https://github.com/jqlang/jq/releases/tag/jq-1.7) release, I made some changes.

- Update links in README.md to the new jqlang organization.
- Update download map to follow changes of executable names.
- Simplify building commands from source code.
- Remove test of empty filter unsupported in 1.7.