### PR TITLE
option to run jq as detached process

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,41 @@ jq.run('.', ['/path/to/file.json'], { output: 'json', sort: true }).then(console
 // },
 ```
 
+### cwd
+
+|           Description            |   Values   |    Default    |
+|:--------------------------------:|:----------:|:-------------:|
+| Set working dir for `jq` process | valid path | process.cwd() |
+
+
+```javascript
+jq.run('.', ['file.json'], { output: 'json', sort: true }, '/path/to').then(console.log)
+// {
+//   "a": 2,
+//   "b": 1
+// },
+```
+
+### detached
+
+|             Description              |     Values      | Default  |
+|:------------------------------------:|:---------------:|:--------:|
+| Run `jq` process as detached process | `true`, `false` | `false`  |
+
+By default `jq` process will run 'attached' to the main process. That means that any interrupt signal main process receives will be propagated to `jq` process. For example, if main process receives `SIGTERM`, `jq` will also receive it and exit immediately.
+
+However, in some cases you might **not** want `jq` to exit immediately and let it exit normally. For example, if you want to implement a graceful shutdown - main process receives `SIGTERM`, it finishes processing current json file and exits after processing is completed.
+
+To achieve that run `jq` detached and NodeJS will not propagate `SIGTERM` to `jq` process allowing it to run until it completes.
+
+```javascript
+jq.run('.', ['file.json'], { output: 'json', sort: true }, undefined, true).then(console.log)
+// {
+//   "a": 2,
+//   "b": 1
+// },
+```
+
 ## Projects using **node-jq**
 
 - **[atom-jq](https://github.com/sanack/atom-jq)**: an [Atom](https://atom.io/) package for manipulating JSON

--- a/src/exec.d.ts
+++ b/src/exec.d.ts
@@ -1,1 +1,1 @@
-export default function(command: string, args: string[], stdin: string, cwd?: string): Promise<string>
+export default function(command: string, args: string[], stdin: string, cwd?: string, detached?: boolean): Promise<string>

--- a/src/exec.js
+++ b/src/exec.js
@@ -3,12 +3,12 @@ import stripFinalNewline from 'strip-final-newline'
 
 const TEN_MEBIBYTE = 1024 * 1024 * 10
 
-const exec = (command, args, stdin, cwd) => {
+const exec = (command, args, stdin, cwd, detached) => {
   return new Promise((resolve, reject) => {
     let stdout = ''
     let stderr = ''
 
-    const spawnOptions = { maxBuffer: TEN_MEBIBYTE, cwd, env: {} }
+    const spawnOptions = { maxBuffer: TEN_MEBIBYTE, cwd, detached, env: {} }
 
     const process = childProcess.spawn(command, args, spawnOptions)
 

--- a/src/jq.d.ts
+++ b/src/jq.d.ts
@@ -1,3 +1,3 @@
 import { PartialOptions } from "./options"
 
-export function run(filter: string, json: any, options?: PartialOptions, jqPath?: string, cwd?: string): Promise<object | string>
+export function run(filter: string, json: any, options?: PartialOptions, jqPath?: string, cwd?: string, detached?: boolean): Promise<object | string>

--- a/src/jq.js
+++ b/src/jq.js
@@ -1,7 +1,7 @@
 import exec from './exec'
 import { commandFactory } from './command'
 
-export const run = (filter, json, options = {}, jqPath, cwd) => {
+export const run = (filter, json, options = {}, jqPath, cwd, detached) => {
   return new Promise((resolve, reject) => {
     const { command, args, stdin } = commandFactory(
       filter,
@@ -10,7 +10,7 @@ export const run = (filter, json, options = {}, jqPath, cwd) => {
       jqPath
     )
 
-    exec(command, args, stdin, cwd)
+    exec(command, args, stdin, cwd, detached)
       .then((stdout) => {
         if (options.output === 'json') {
           let result

--- a/src/jq.test.js
+++ b/src/jq.test.js
@@ -181,4 +181,15 @@ describe('jq core', () => {
         done(error)
       })
   })
+
+  it('should run as detached', done => {
+    run(FILTER_VALID, PATH_JSON_FIXTURE, undefined, undefined, undefined, true)
+      .then(output => {
+        expect(output).to.equal('"git"')
+        done()
+      })
+      .catch(error => {
+        done(error)
+      })
+  })
 })


### PR DESCRIPTION
when an app receives SIGTERM it propagates it to a child `jq` process and `node-jq` throws an error.

this makes graceful shutdown of an app impossible. 

this PR allows `jq` to run as detached process so that SIGTERM is not propagated allowing it to exit normally.