### PR TITLE
Add custom args to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,9 @@ jq.run('.', ['/path/to/file.json','/path/to/other_file.json'], { output: 'json',
 
 ### sort
 
-|         Description                   |     Values      | Default |
-|:-------------------------------------:|:---------------:|:-------:|
-| Sort object keys in alphabetical order| `true`, `false` | `false` |
+|         Description                   |     Values      |  Default  |
+|:-------------------------------------:|:---------------:|:---------:|
+| Sort object keys in alphabetical order| `true`, `false` | undefined |
 
 #### `sort: true`
 
@@ -235,6 +235,23 @@ jq.run('.', ['/path/to/file.json'], { output: 'json', sort: true }).then(console
 //   "a": 2,
 //   "b": 1
 // },
+```
+
+### args
+
+|         Description                   |        Values        |   Default   |
+|:-------------------------------------:|:--------------------:|:-----------:|
+| Send custom args to the jq command    | `[string]`, `string` | `undefined` |
+
+#### `args: ['--arg','myfruit','orange']`
+
+Adds the `--arg myfruit orange` arguments to the internal jq command
+
+```javascript
+jq.run('{"fruit":$myfruit}', ['/path/to/file.json'], { output: 'json', sort: true, args: ['--arg','myfruit','orange'] }).then(console.log)
+// {
+//   fruit: "orange"
+// }
 ```
 
 ### cwd

--- a/README.md
+++ b/README.md
@@ -221,9 +221,9 @@ jq.run('.', ['/path/to/file.json','/path/to/other_file.json'], { output: 'json',
 
 ### sort
 
-|         Description                   |     Values      |  Default  |
-|:-------------------------------------:|:---------------:|:---------:|
-| Sort object keys in alphabetical order| `true`, `false` | undefined |
+|         Description                   |     Values      | Default |
+|:-------------------------------------:|:---------------:|:-------:|
+| Sort object keys in alphabetical order| `true`, `false` | `false` |
 
 #### `sort: true`
 

--- a/README.md
+++ b/README.md
@@ -241,16 +241,19 @@ jq.run('.', ['/path/to/file.json'], { output: 'json', sort: true }).then(console
 
 |         Description                   |        Values        |   Default   |
 |:-------------------------------------:|:--------------------:|:-----------:|
-| Send custom args to the jq command    | `[string]`, `string` | `undefined` |
+| Send custom args to the jq command    | `[object]`           | `undefined` |
 
-#### `args: ['--arg','myfruit','orange']`
+#### `args: { myfruit: { hello: 'orange'}, myfruit2: "banana" }`
 
-Adds the `--arg myfruit orange` arguments to the internal jq command
+Adds the `--argjson myfruit "{ 'hello': 'orange' }" --arg myfruit2 orange` arguments to the internal jq command
 
 ```javascript
-jq.run('{"fruit":$myfruit}', ['/path/to/file.json'], { output: 'json', sort: true, args: ['--arg','myfruit','orange'] }).then(console.log)
+jq.run('{"fruit":$myfruit,"fruit2":$myfruit2}', ['/path/to/file.json'], { output: 'json', sort: true, args: { myfruit: { hello: 'orange' }, myfruit2: "banana" } }).then(console.log)
 // {
-//   fruit: "orange"
+//   fruit: { 
+//      hello: "orange" 
+//   },
+//   fruit2: "banana"
 // }
 ```
 

--- a/src/options.d.ts
+++ b/src/options.d.ts
@@ -13,6 +13,6 @@ interface IOptions {
     raw: boolean,
     slurp: boolean,
     sort: boolean,
-    args: string | string[]
+    args: { [key: string]: object | string }
 }
 export type PartialOptions = Partial<IOptions>

--- a/src/options.d.ts
+++ b/src/options.d.ts
@@ -13,5 +13,6 @@ interface IOptions {
     raw: boolean,
     slurp: boolean,
     sort: boolean,
+    args: string | string[]
 }
 export type PartialOptions = Partial<IOptions>

--- a/src/options.js
+++ b/src/options.js
@@ -35,7 +35,7 @@ export const optionsSchema = Joi.object({
   raw: strictBoolean,
   slurp: strictBoolean,
   sort: strictBoolean,
-  args: [Joi.array().items(Joi.string()), Joi.string()],
+  args: [Joi.array().items(Joi.string()), Joi.string()]
 
 })
 

--- a/src/options.js
+++ b/src/options.js
@@ -83,12 +83,13 @@ export const spawnSchema = Joi.object({
       then: Joi.array().default(Joi.ref('$options.args', {
         adjust: (value) => {
           return Object.keys(value).map((key) => {
-            switch(typeof value[key]) {
+            switch (typeof value[key]) {
+              case 'string':
+                return ['--arg', key, value[key]]
+              case 'object':
+                return ['--argjson', key, JSON.stringify(value[key])]
               default:
-              case "string":
-                  return ["--arg",key,value[key]];
-              case "object":
-                  return ["--argjson",key,JSON.stringify(value[key])]
+                return ['--arg', key, value[key]]
             }
           }).flat()
         }

--- a/src/options.js
+++ b/src/options.js
@@ -35,8 +35,7 @@ export const optionsSchema = Joi.object({
   raw: strictBoolean,
   slurp: strictBoolean,
   sort: strictBoolean,
-  args: [Joi.array().items(Joi.string()), Joi.string()]
-
+  args: Joi.object().unknown()
 })
 
 export const preSpawnSchema = Joi.object({
@@ -80,10 +79,18 @@ export const spawnSchema = Joi.object({
     slurp: createBooleanSchema('$options.slurp', '--slurp'),
     sort: createBooleanSchema('$options.sort', '--sort-keys'),
     args: Joi.array().when('$options.args', {
-      is: [Joi.array().items(Joi.string()), Joi.string()],
+      is: Joi.object().required(),
       then: Joi.array().default(Joi.ref('$options.args', {
         adjust: (value) => {
-          return [].concat(value)
+          return Object.keys(value).map((key) => {
+            switch(typeof value[key]) {
+              default:
+              case "string":
+                  return ["--arg",key,value[key]];
+              case "object":
+                  return ["--argjson",key,JSON.stringify(value[key])]
+            }
+          }).flat()
         }
       }))
     })

--- a/src/options.js
+++ b/src/options.js
@@ -80,25 +80,6 @@ export const spawnSchema = Joi.object({
     slurp: createBooleanSchema('$options.slurp', '--slurp'),
     sort: createBooleanSchema('$options.sort', '--sort-keys'),
     args: Joi.array().when('$options.args', {
-      // switch: [
-      //   // { 
-      //   //   is: Joi.array().items(Joi.string()),
-      //   //   then: Joi.array().default(Joi.ref('$options.args', {
-      //   //     adjust: (value) => {
-      //   //       return [].concat(value)
-      //   //     }
-      //   //   }))
-      //   // },
-      //   { 
-      //     is: Joi.string(),
-      //     then: Joi.array().default(Joi.ref('$options.args', {
-      //       adjust: (value) => {
-      //         console.log('value', value)
-      //         return [].concat(value)
-      //       }
-      //     }))
-      //   }
-      // ]
       is: [Joi.array().items(Joi.string()), Joi.string()],
       then: Joi.array().default(Joi.ref('$options.args', {
         adjust: (value) => {

--- a/src/options.js
+++ b/src/options.js
@@ -34,7 +34,9 @@ export const optionsSchema = Joi.object({
   output: Joi.string().default('pretty').valid('string', 'compact', 'pretty', 'json'),
   raw: strictBoolean,
   slurp: strictBoolean,
-  sort: strictBoolean
+  sort: strictBoolean,
+  args: [Joi.array().items(Joi.string()), Joi.string()],
+
 })
 
 export const preSpawnSchema = Joi.object({
@@ -76,7 +78,34 @@ export const spawnSchema = Joi.object({
     }),
     raw: createBooleanSchema('$options.raw', '-r'),
     slurp: createBooleanSchema('$options.slurp', '--slurp'),
-    sort: createBooleanSchema('$options.sort', '--sort-keys')
+    sort: createBooleanSchema('$options.sort', '--sort-keys'),
+    args: Joi.array().when('$options.args', {
+      // switch: [
+      //   // { 
+      //   //   is: Joi.array().items(Joi.string()),
+      //   //   then: Joi.array().default(Joi.ref('$options.args', {
+      //   //     adjust: (value) => {
+      //   //       return [].concat(value)
+      //   //     }
+      //   //   }))
+      //   // },
+      //   { 
+      //     is: Joi.string(),
+      //     then: Joi.array().default(Joi.ref('$options.args', {
+      //       adjust: (value) => {
+      //         console.log('value', value)
+      //         return [].concat(value)
+      //       }
+      //     }))
+      //   }
+      // ]
+      is: [Joi.array().items(Joi.string()), Joi.string()],
+      then: Joi.array().default(Joi.ref('$options.args', {
+        adjust: (value) => {
+          return [].concat(value)
+        }
+      }))
+    })
   }).default(),
   stdin: Joi.string().default('').alter({
     json: (schema) => schema.default(Joi.ref('$json', {

--- a/src/options.js
+++ b/src/options.js
@@ -105,7 +105,7 @@ export const parseOptions = (options = {}, filter, json) => {
       .reduce((list, key) => list.concat(validatedSpawn.args[key]), [])
       .concat(filter, json)
   }
-  return Object.values(validatedSpawn.args).concat(filter)
+  return Object.values(validatedSpawn.args).flat().concat(filter)
 }
 
 export const optionDefaults = Joi.attempt({}, optionsSchema)

--- a/src/options.test.js
+++ b/src/options.test.js
@@ -379,7 +379,31 @@ describe('options', () => {
   })
 
   describe('send args as option', () => {
-    it('should send args to jq execution', done => {
+    it('should send --arg to jq execution', done => {
+      run('{"fruit":$myfruit}', {}, {
+        input: 'json',
+        output: 'json',
+        args: { myfruit: 'orange' }
+      })
+        .then(output => {
+          expect(output).to.eql({ fruit: 'orange' })
+          done()
+        })
+        .catch(e => done(e))
+    })
+    it('should send --argjson to jq execution', done => {
+      run('{"fruit":$myfruit}', {}, {
+        input: 'json',
+        output: 'json',
+        args: { myfruit: { hello: 'orange' } }
+      })
+        .then(output => {
+          expect(output).to.eql({ fruit: { hello: 'orange' } })
+          done()
+        })
+        .catch(e => done(e))
+    })
+    it('should send both --arg and --argjson to jq execution', done => {
       run('{"fruit":$myfruit,"fruit2":$myfruit2}', {}, {
         input: 'json',
         output: 'json',

--- a/src/options.test.js
+++ b/src/options.test.js
@@ -378,21 +378,19 @@ describe('options', () => {
     })
   })
 
-  describe('send custom args',() => {
-    it("should send custom args to jq execution", done => {
+  describe('send custom args', () => {
+    it('should send custom args to jq execution', done => {
       run('{"fruit":$myfruit}', PATH_JSON_FIXTURE, {
         input: 'file',
         output: 'json',
-        args: ['--arg','myfruit','orange'],
+        args: ['--arg', 'myfruit', 'orange']
       })
-      .then(output => {
-        
-        expect(output).to.eql({fruit:"orange"})
-        done()
-      })
-      .catch(e => done(e))
+        .then(output => {
+          expect(output).to.eql({ fruit: 'orange' })
+          done()
+        })
+        .catch(e => done(e))
     })
-
   })
 
   describe('inherited env var', () => {

--- a/src/options.test.js
+++ b/src/options.test.js
@@ -378,10 +378,25 @@ describe('options', () => {
     })
   })
 
-  describe('send custom args', () => {
+  describe('send custom args when input = file', () => {
     it('should send custom args to jq execution', done => {
       run('{"fruit":$myfruit}', PATH_JSON_FIXTURE, {
         input: 'file',
+        output: 'json',
+        args: ['--arg', 'myfruit', 'orange']
+      })
+        .then(output => {
+          expect(output).to.eql({ fruit: 'orange' })
+          done()
+        })
+        .catch(e => done(e))
+    })
+  })
+
+  describe('send custom args when input = json', () => {
+    it('should send custom args to jq execution', done => {
+      run('{"fruit":$myfruit}', {}, {
+        input: 'json',
         output: 'json',
         args: ['--arg', 'myfruit', 'orange']
       })

--- a/src/options.test.js
+++ b/src/options.test.js
@@ -378,6 +378,23 @@ describe('options', () => {
     })
   })
 
+  describe('send custom args',() => {
+    it("should send custom args to jq execution", done => {
+      run('{"fruit":$myfruit}', PATH_JSON_FIXTURE, {
+        input: 'file',
+        output: 'json',
+        args: ['--arg','myfruit','orange'],
+      })
+      .then(output => {
+        
+        expect(output).to.eql({fruit:"orange"})
+        done()
+      })
+      .catch(e => done(e))
+    })
+
+  })
+
   describe('inherited env var', () => {
     it('process.env should not be sent in to jq execution', done => {
       process.env.X_TEST_ENV_VAR = 'TEST_VALUE'

--- a/src/options.test.js
+++ b/src/options.test.js
@@ -378,35 +378,21 @@ describe('options', () => {
     })
   })
 
-  describe('send custom args when input = file', () => {
-    it('should send custom args to jq execution', done => {
-      run('{"fruit":$myfruit}', PATH_JSON_FIXTURE, {
-        input: 'file',
+  describe('send args as option', () => {
+    it('should send args to jq execution', done => {
+      run('{"fruit":$myfruit,"fruit2":$myfruit2}', {}, {
+        input: 'json',
         output: 'json',
-        args: ['--arg', 'myfruit', 'orange']
+        args: {myfruit:{hello:'orange'},myfruit2:"banana"}
       })
         .then(output => {
-          expect(output).to.eql({ fruit: 'orange' })
+          expect(output).to.eql({ fruit: {hello:'orange'}, fruit2: "banana" })
           done()
         })
         .catch(e => done(e))
     })
   })
 
-  describe('send custom args when input = json', () => {
-    it('should send custom args to jq execution', done => {
-      run('{"fruit":$myfruit}', {}, {
-        input: 'json',
-        output: 'json',
-        args: ['--arg', 'myfruit', 'orange']
-      })
-        .then(output => {
-          expect(output).to.eql({ fruit: 'orange' })
-          done()
-        })
-        .catch(e => done(e))
-    })
-  })
 
   describe('inherited env var', () => {
     it('process.env should not be sent in to jq execution', done => {

--- a/src/options.test.js
+++ b/src/options.test.js
@@ -383,16 +383,15 @@ describe('options', () => {
       run('{"fruit":$myfruit,"fruit2":$myfruit2}', {}, {
         input: 'json',
         output: 'json',
-        args: {myfruit:{hello:'orange'},myfruit2:"banana"}
+        args: { myfruit: { hello: 'orange' }, myfruit2: 'banana' }
       })
         .then(output => {
-          expect(output).to.eql({ fruit: {hello:'orange'}, fruit2: "banana" })
+          expect(output).to.eql({ fruit: { hello: 'orange' }, fruit2: 'banana' })
           done()
         })
         .catch(e => done(e))
     })
   })
-
 
   describe('inherited env var', () => {
     it('process.env should not be sent in to jq execution', done => {


### PR DESCRIPTION
node-jq is an excellent library. However it is a bit limited by functionality. I added the capability to send custom args to the jq command to fully unlock the functionality and make it available via this library.