### PR TITLE
fix: ensure bin/jq symlinked to node_modules/.bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "standard --verbose | snazzy",
     "build": "swc ./src --delete-dir-on-start -d lib",
     "copy-ts-defintions": "copyfiles src/*.d.ts lib -f",
-    "postinstall": "npm run install-binary",
+    "preinstall": "npm run install-binary",
     "coverage": "nyc report --reporter=lcov",
     "precodeclimate": "npm run coverage",
     "codeclimate": "codeclimate-test-reporter < coverage/lcov.info",


### PR DESCRIPTION
It appears that if bin/jq doesn't exist during the npm install target,
it won't get symlinked to ~/node_modules/.bin
So fetch it in preinstall instead

fixes: #669
