### PR TITLE
[FIX] WIndows binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,86 +1,86 @@
 {
-  "name": "node-jq",
-  "version": "0.0.0-semantic-release",
-  "description": "Run jq in node",
-  "main": "lib/jq.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/sanack/node-jq"
-  },
-  "bin": {
-    "node-jq": "bin/jq"
-  },
-  "scripts": {
-    "pretest": "npm run install-binary",
-    "install-binary": "node scripts/install-binary.js",
-    "test": "nyc mocha src/*.test.js -r @swc-node/register",
-    "test:watch": "npm test -- --watch",
-    "lint": "standard --verbose | snazzy",
-    "build": "swc ./src --delete-dir-on-start -d lib",
-    "copy-ts-defintions": "copyfiles src/*.d.ts lib -f",
-    "preinstall": "npm run install-binary",
-    "coverage": "nyc report --reporter=lcov",
-    "precodeclimate": "npm run coverage",
-    "codeclimate": "codeclimate-test-reporter < coverage/lcov.info",
-    "semantic-release": "semantic-release"
-  },
-  "engines": {
-    "node": ">= 16"
-  },
-  "keywords": [
-    "jq",
-    "json"
-  ],
-  "author": "sanack",
-  "contributors": [
-    {
-      "name": "davesnx",
-      "email": "dsnxmoreno@gmail.com"
-    },
-    {
-      "name": "mackermans",
-      "email": "maarten.ackermans@gmail.com"
-    }
-  ],
-  "license": "MIT",
-  "files": [
-    "src",
-    "lib",
-    "scripts",
-    "docs"
-  ],
-  "dependencies": {
-    "bin-build": "^3.0.0",
-    "is-valid-path": "^0.1.1",
-    "joi": "^17.4.0",
-    "node-downloader-helper": "^2.1.6",
-    "strip-final-newline": "^2.0.0",
-    "tempfile": "^3.0.0"
-  },
-  "devDependencies": {
-    "@arkweid/lefthook": "^0.7.7",
-    "@semantic-release/changelog": "^6.0.3",
-    "@semantic-release/commit-analyzer": "^10.0.1",
-    "@semantic-release/github": "^9.0.4",
-    "@semantic-release/npm": "^10.0.4",
-    "@semantic-release/release-notes-generator": "^11.0.4",
-    "@swc-node/register": "^1.4.0",
-    "@swc/cli": "^0.1.57",
-    "@swc/core": "^1.2.161",
-    "chai": "^4.2.0",
-    "codeclimate-test-reporter": "^0.5.1",
-    "copyfiles": "^2.4.1",
-    "mocha": "^10.0.0",
-    "nyc": "^15.1.0",
-    "semantic-release": "^21.0.7",
-    "snazzy": "^9.0.0",
-    "standard": "^17.0.0",
-    "validate-commit-msg": "^2.14.0"
-  },
-  "standard": {
-    "global": [
-      "describe",
-      "it"
-    ]
-  }
+	"name": "node-jq",
+	"version": "0.0.0-semantic-release",
+	"description": "Run jq in node",
+	"main": "lib/jq.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/sanack/node-jq"
+	},
+	"bin": {
+		"node-jq": "bin/jq.exe"
+	},
+	"scripts": {
+		"pretest": "npm run install-binary",
+		"install-binary": "node scripts/install-binary.js",
+		"test": "nyc mocha src/*.test.js -r @swc-node/register",
+		"test:watch": "npm test -- --watch",
+		"lint": "standard --verbose | snazzy",
+		"build": "swc ./src --delete-dir-on-start -d lib",
+		"copy-ts-defintions": "copyfiles src/*.d.ts lib -f",
+		"preinstall": "npm run install-binary",
+		"coverage": "nyc report --reporter=lcov",
+		"precodeclimate": "npm run coverage",
+		"codeclimate": "codeclimate-test-reporter < coverage/lcov.info",
+		"semantic-release": "semantic-release"
+	},
+	"engines": {
+		"node": ">= 16"
+	},
+	"keywords": [
+		"jq",
+		"json"
+	],
+	"author": "sanack",
+	"contributors": [
+		{
+			"name": "davesnx",
+			"email": "dsnxmoreno@gmail.com"
+		},
+		{
+			"name": "mackermans",
+			"email": "maarten.ackermans@gmail.com"
+		}
+	],
+	"license": "MIT",
+	"files": [
+		"src",
+		"lib",
+		"scripts",
+		"docs"
+	],
+	"dependencies": {
+		"bin-build": "^3.0.0",
+		"is-valid-path": "^0.1.1",
+		"joi": "^17.4.0",
+		"node-downloader-helper": "^2.1.6",
+		"strip-final-newline": "^2.0.0",
+		"tempfile": "^3.0.0"
+	},
+	"devDependencies": {
+		"@arkweid/lefthook": "^0.7.7",
+		"@semantic-release/changelog": "^6.0.3",
+		"@semantic-release/commit-analyzer": "^10.0.1",
+		"@semantic-release/github": "^9.0.4",
+		"@semantic-release/npm": "^10.0.4",
+		"@semantic-release/release-notes-generator": "^11.0.4",
+		"@swc-node/register": "^1.4.0",
+		"@swc/cli": "^0.1.57",
+		"@swc/core": "^1.2.161",
+		"chai": "^4.2.0",
+		"codeclimate-test-reporter": "^0.5.1",
+		"copyfiles": "^2.4.1",
+		"mocha": "^10.0.0",
+		"nyc": "^15.1.0",
+		"semantic-release": "^21.0.7",
+		"snazzy": "^9.0.0",
+		"standard": "^17.0.0",
+		"validate-commit-msg": "^2.14.0"
+	},
+	"standard": {
+		"global": [
+			"describe",
+			"it"
+		]
+	}
 }

--- a/scripts/install-binary.js
+++ b/scripts/install-binary.js
@@ -17,8 +17,8 @@ async function download (url, saveDirectory) {
     downloader.on('progress.throttled', (downloadEvents) => {
       const percentageComplete =
           downloadEvents.progress < 100
-              ? downloadEvents.progress.toPrecision(2)
-              : 100
+            ? downloadEvents.progress.toPrecision(2)
+            : 100
       console.info(`Downloaded: ${percentageComplete}%`)
     })
 
@@ -42,17 +42,17 @@ const JQ_NAME_MAP = {
 const JQ_NAME =
     platform in JQ_NAME_MAP ? JQ_NAME_MAP[platform] : JQ_NAME_MAP.def
 
-const PACKAGE_FOLDER =  path.join(__dirname, '..')
-const PACKAGE_FILE =  path.join(PACKAGE_FOLDER, 'package.json')
+const PACKAGE_FOLDER = path.join(__dirname, '..')
+const PACKAGE_FILE = path.join(PACKAGE_FOLDER, 'package.json')
 const OUTPUT_DIR = path.join(__dirname, '..', 'bin')
 const OUTPUT_FILE = path.join(OUTPUT_DIR, JQ_NAME)
 
 const renamePackageBin = () => {
-  const __package = JSON.parse(fs.readFileSync(PACKAGE_FILE,{encoding: "utf-8"}))
+  const __package = JSON.parse(fs.readFileSync(PACKAGE_FILE, { encoding: 'utf-8' }))
   __package.bin = {
-    "node-jq": path.relative(PACKAGE_FOLDER,OUTPUT_FILE).split("\\").join('/')
+    'node-jq': path.relative(PACKAGE_FOLDER, OUTPUT_FILE).split('\\').join('/')
   }
-  fs.writeFileSync(PACKAGE_FILE,JSON.stringify(__package,null,"\t"));
+  fs.writeFileSync(PACKAGE_FILE, JSON.stringify(__package, null, '\t'))
 }
 
 const fileExist = (path) => {
@@ -104,21 +104,21 @@ if (platform in DOWNLOAD_MAP && arch in DOWNLOAD_MAP[platform]) {
 
   console.log(`Downloading jq from ${url}`)
   download(url, OUTPUT_DIR)
-      .then(() => {
-        fs.renameSync(path.join(OUTPUT_DIR, filename), OUTPUT_FILE)
-        if (fileExist(OUTPUT_FILE)) {
-          // fs.chmodSync(OUTPUT_FILE, fs.constants.S_IXUSR || 0o100)
-          // Huan(202111): we need the read permission so that the build system can pack the node_modules/ folder,
-          // i.e. build with Heroku CI/CD, docker build, etc.
-          fs.chmodSync(OUTPUT_FILE, 0o755)
-        }
-        renamePackageBin()
-        console.log(`Downloaded in ${OUTPUT_DIR}`)
-      })
-      .catch(err => {
-        console.error(err)
-        process.exit(1)
-      })
+    .then(() => {
+      fs.renameSync(path.join(OUTPUT_DIR, filename), OUTPUT_FILE)
+      if (fileExist(OUTPUT_FILE)) {
+        // fs.chmodSync(OUTPUT_FILE, fs.constants.S_IXUSR || 0o100)
+        // Huan(202111): we need the read permission so that the build system can pack the node_modules/ folder,
+        // i.e. build with Heroku CI/CD, docker build, etc.
+        fs.chmodSync(OUTPUT_FILE, 0o755)
+      }
+      renamePackageBin()
+      console.log(`Downloaded in ${OUTPUT_DIR}`)
+    })
+    .catch(err => {
+      console.error(err)
+      process.exit(1)
+    })
 } else {
   // download source and build
 
@@ -126,17 +126,17 @@ if (platform in DOWNLOAD_MAP && arch in DOWNLOAD_MAP[platform]) {
 
   console.log(`Building jq from ${url}`)
   binBuild
-      .url(url, [
+    .url(url, [
         `./configure --with-oniguruma=builtin --prefix=${tempfile()} --bindir=${OUTPUT_DIR}`,
         'make -j8',
         'make install'
-      ])
-      .then(() => {
-        renamePackageBin()
-        console.log(`jq installed successfully on ${OUTPUT_DIR}`)
-      })
-      .catch(err => {
-        console.error(err)
-        process.exit(1)
-      })
+    ])
+    .then(() => {
+      renamePackageBin()
+      console.log(`jq installed successfully on ${OUTPUT_DIR}`)
+    })
+    .catch(err => {
+      console.error(err)
+      process.exit(1)
+    })
 }

--- a/scripts/install-binary.js
+++ b/scripts/install-binary.js
@@ -47,6 +47,14 @@ const PACKAGE_FILE =  path.join(PACKAGE_FOLDER, 'package.json')
 const OUTPUT_DIR = path.join(__dirname, '..', 'bin')
 const OUTPUT_FILE = path.join(OUTPUT_DIR, JQ_NAME)
 
+const renamePackageBin = () => {
+  const __package = JSON.parse(fs.readFileSync(PACKAGE_FILE,{encoding: "utf-8"}))
+  __package.bin = {
+    "node-jq": path.relative(PACKAGE_FOLDER,OUTPUT_FILE).split("\\").join('/')
+  }
+  fs.writeFileSync(PACKAGE_FILE,JSON.stringify(__package,null,"\t"));
+}
+
 const fileExist = (path) => {
   try {
     return fs.existsSync(path)
@@ -62,6 +70,7 @@ if (!fs.existsSync(OUTPUT_DIR)) {
 
 if (fileExist(OUTPUT_FILE)) {
   console.log('jq is already installed')
+  renamePackageBin()
   process.exit(0)
 }
 
@@ -103,6 +112,7 @@ if (platform in DOWNLOAD_MAP && arch in DOWNLOAD_MAP[platform]) {
           // i.e. build with Heroku CI/CD, docker build, etc.
           fs.chmodSync(OUTPUT_FILE, 0o755)
         }
+        renamePackageBin()
         console.log(`Downloaded in ${OUTPUT_DIR}`)
       })
       .catch(err => {
@@ -122,6 +132,7 @@ if (platform in DOWNLOAD_MAP && arch in DOWNLOAD_MAP[platform]) {
         'make install'
       ])
       .then(() => {
+        renamePackageBin()
         console.log(`jq installed successfully on ${OUTPUT_DIR}`)
       })
       .catch(err => {


### PR DESCRIPTION
I encountered issues when running the `node-jq` binary from the package. I discovered that if you don't append `.exe` to the `bin` package file path, the binary isn't added/symlinked in the `node_module/.bin/` repository, resulting in the binary not being resolved.

In response to this issue, I've added the `renamePackageBin` function, which forces to assign the full filename as the binary file in the `package.json`, resolving the problem.

I've executed this function in all OS contexts, which should work, but we can consider guarding it for Windows only (when the filename ends by `.exe`, for example).