### PR TITLE
fix: remove setEncoding on write stream

### DIFF
--- a/src/exec.js
+++ b/src/exec.js
@@ -32,7 +32,6 @@ const exec = (command, args, stdin, cwd, detached) => {
           return reject(err)
         }
       })
-      process.stdin.setEncoding('utf-8')
       process.stdin.write(stdin)
       process.stdin.end()
     }


### PR DESCRIPTION
This PR fixes https://github.com/sanack/node-jq/issues/681

* remove setEncoding on a Writable stream (break [bun](https://bun.sh) runtime)

The reason behind this issue is that `Writable.setEncoding` is not part of the node API and will break in the [bun](https://bun.sh) runtime. Since "utf8" is the default encoding anyways, this setting should be safe to be removed.