### PR TITLE
Update jq version to 1.7.1

### DIFF
--- a/scripts/install-binary.js
+++ b/scripts/install-binary.js
@@ -32,7 +32,7 @@ const arch = process.arch
 const JQ_INFO = {
   name: 'jq',
   url: 'https://github.com/jqlang/jq/releases/download/',
-  version: 'jq-1.7'
+  version: 'jq-1.7.1'
 }
 
 const JQ_NAME_MAP = {


### PR DESCRIPTION
1.7.1 has been released in Dec 2023, including two buffer overflow fixes:

https://github.com/jqlang/jq/releases/tag/jq-1.7.1