### PR TITLE
feat: add support for local jq binary via .npmrc configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ npx node-jq '.foo' package.json
 
 By default, `node-jq` downloads `jq` during the installation process with a post-install script. Depending on your SO downloads from [https://github.com/jqlang/jq/releases] into `./node_modules/node-jq/bin/jq` to avoid colisions with any global installation. Check #161 #167 #171 for more information. You can safely rely on this location for your installed `jq`, we won't change this path without a major version upgrade.
 
+### Skipping binary installation
+
 If you want to skip the installation step of `jq`, you can set `NODE_JQ_SKIP_INSTALL_BINARY` to `true` or ignore the post-install script from the installation `npm install node-jq --ignore-scripts`.
 
 ```bash
@@ -40,6 +42,31 @@ npm install node-jq
 ```bash
 npm install node-jq --ignore-scripts
 ```
+
+### Using a local jq binary
+
+If you have `jq` already installed on your system or in environments where downloading binaries is restricted, you can configure `node-jq` to use a local binary instead. Add the following to your `.npmrc` file:
+
+```bash
+# Use jq from system PATH
+jq-path=jq
+
+# Or specify an absolute path
+jq-path=/usr/local/bin/jq
+```
+
+Then install normally:
+
+```bash
+npm install node-jq --save
+```
+
+This approach is ideal for:
+- Corporate environments where web downloads are disallowed
+- Systems where `jq` is available through package managers
+- Build environments that need reproducible installations
+
+The configuration is automatically picked up from `.npmrc` and can be version-controlled with your project.
 
 ## Usage
 
@@ -109,8 +136,21 @@ jq.run(filter, jsonPath, options)
 
 ### path to jq binary
 
-By default, the `jq` binary installed with the package is used. If you have special needs or want to use another binary in a different
-path you can set the environment variable `JQ_PATH` to override the binary path.
+By default, the `jq` binary installed with the package is used. You can override this in several ways:
+
+1. **`.npmrc` configuration** (recommended for project-level settings):
+   ```bash
+   jq-path=jq
+   # or
+   jq-path=/usr/local/bin/jq
+   ```
+
+2. **Environment variable** (for runtime overrides):
+   ```bash
+   export JQ_PATH=/path/to/jq
+   ```
+
+The priority order is: `JQ_PATH` environment variable → `.npmrc` configuration → downloaded binary.
 
 ### input
 

--- a/scripts/install-binary.mjs
+++ b/scripts/install-binary.mjs
@@ -2,6 +2,12 @@
 
 'use strict'
 
+// First check if the user has configured a local jq binary
+if (process.env.npm_config_jq_path) {
+  console.log(`Using configured local jq binary: ${process.env.npm_config_jq_path}`)
+  process.exit(0)
+}
+
 import { spawn } from 'node:child_process'
 import {
   chmodSync,

--- a/src/command.ts
+++ b/src/command.ts
@@ -7,7 +7,10 @@ import {
   type OptionsInput,
 } from './options'
 
-const JQ_PATH = process.env.JQ_PATH ?? path.join(__dirname, '..', 'bin', 'jq')
+const JQ_PATH =
+  process.env.JQ_PATH ??
+  process.env.npm_config_jq_path ??
+  path.join(__dirname, '..', 'bin', 'jq')
 
 const validateArguments = (
   filter: FilterInput,


### PR DESCRIPTION
# Add support for local jq binary via .npmrc configuration

## Summary

This PR introduces a new configuration mechanism that allows users to specify a local `jq` binary path through their `.npmrc` file, enabling the use of `node-jq` in restrictive environments where downloading binaries is prohibited.

## Problem

Currently, `node-jq` downloads the `jq` binary during installation from GitHub releases. This approach fails in environments with:

- **Network restrictions**: Corporate firewalls that block downloads from external sources
- **Security policies**: Organizations that prohibit downloading executables during build processes
- **Immutable environments**: Container builds or CI/CD pipelines where external downloads are not allowed
- **Configuration constraints**: Environments where setting arbitrary environment variables during install, build, or runtime is not possible or practical

The existing `JQ_PATH` environment variable and `NODE_JQ_SKIP_INSTALL_BINARY` workarounds require runtime environment configuration, which isn't always feasible in managed or containerized environments.

## Solution

This PR adds support for configuring the `jq` binary path through npm's built-in configuration system via `.npmrc`:

```bash
# Use jq from system PATH
jq-path=jq

# Or specify an absolute path
jq-path=/usr/local/bin/jq
```

### Key Features

1. **Installation-time configuration**: The install script checks for `npm_config_jq_path` and skips binary download when configured
2. **Runtime binary resolution**: Updated priority hierarchy for finding the `jq` binary
3. **Version-controllable**: `.npmrc` configuration can be committed to source control
4. **Reproducible builds**: Teams can ensure consistent binary usage across environments
5. **Zero additional dependencies**: Uses npm's existing configuration mechanism

### Binary Resolution Priority

The new priority order is:
1. `JQ_PATH` environment variable (highest priority - runtime override)
2. `npm_config_jq_path` from `.npmrc` (medium priority - project configuration)
3. Downloaded binary in `./bin/jq` (lowest priority - fallback)

## Changes

### Core Implementation

- **`scripts/install-binary.mjs`**: Added early exit when `npm_config_jq_path` is detected
- **`src/command.ts`**: Enhanced binary path resolution to include `.npmrc` configuration

### Documentation

- **`README.md`**: Added comprehensive documentation including:
  - New "Using a local jq binary" section with usage examples
  - Updated "path to jq binary" section explaining all configuration methods
  - Clear priority hierarchy explanation
  - Use case examples for restrictive environments

## Usage Example

For organizations with restricted environments:

1. **Project setup** (one-time):
   ```bash
   echo "jq-path=jq" >> .npmrc
   git add .npmrc
   git commit -m "Configure node-jq to use system jq binary"
   ```

2. **Installation** (works in any environment):
   ```bash
   npm install node-jq --save
   # No download occurs, uses system jq
   ```

3. **Reproducible deployment**:
   ```bash
   npm ci  # Respects .npmrc configuration automatically
   ```

## Benefits

- **Addresses restrictive environments**: Solves the core problem of download restrictions
- **Removes configuration burden**: No need to manage environment variables in deployment pipelines
- **Improves security posture**: Uses system-managed binaries instead of downloaded executables
- **Maintains backward compatibility**: Existing installations continue to work unchanged
- **Leverages npm standards**: Uses npm's built-in configuration system rather than custom solutions

## Testing

The changes maintain full backward compatibility:
- Existing installations continue to download and use bundled binaries
- `JQ_PATH` environment variable continues to work as before
- `NODE_JQ_SKIP_INSTALL_BINARY` behavior is unchanged

## Breaking Changes

None. This is a purely additive feature that enhances existing functionality without modifying current behavior.

## Related Issues

This change addresses common deployment challenges in enterprise and containerized environments where external downloads are restricted but system package managers provide approved `jq` installations.
