### PR TITLE
Ensure jq path doesnt download

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,3 @@
 **/*{.,-}min.js
+lib/*
+node_modules/*

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
-# Rewrite to TypeScript and zod
+# Rewrite to TypeScript and zod in v6.0.0
 679a12725685be763919bb6b572d2065c791b2e6

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Rewrite to TypeScript and zod
+679a12725685be763919bb6b572d2065c791b2e6

--- a/README.md
+++ b/README.md
@@ -28,45 +28,36 @@ npx node-jq '.foo' package.json
 
 ## Advanced installation
 
-By default, `node-jq` downloads `jq` during the installation process with a post-install script. Depending on your SO downloads from [https://github.com/jqlang/jq/releases] into `./node_modules/node-jq/bin/jq` to avoid colisions with any global installation. Check #161 #167 #171 for more information. You can safely rely on this location for your installed `jq`, we won't change this path without a major version upgrade.
+By default, `node-jq` downloads `jq` during the installation process with a post-install script. Depending on your OS it downloads from [https://github.com/jqlang/jq/releases] into `./node_modules/node-jq/bin/jq` to avoid colisions with any global installation. Check #161 #167 #171 for more information. You can safely rely on this location for your installed `jq`, we won't change this path without a major version upgrade.
 
-### Skipping binary installation
+### Skipping binary installation and use your local jq
 
-If you want to skip the installation step of `jq`, you can set `NODE_JQ_SKIP_INSTALL_BINARY` to `true` or ignore the post-install script from the installation `npm install node-jq --ignore-scripts`.
+If you want to skip the installation step of `jq`, you can do it with different mechanisms. `node-jq` will assume `jq` is in `$PATH` when skipping the installation.
 
-```bash
-export NODE_JQ_SKIP_INSTALL_BINARY=true
-npm install node-jq
-```
+Choose the one that fits best your needs:
 
-```bash
-npm install node-jq --ignore-scripts
-```
-
-### Using a local jq binary
-
-If you have `jq` already installed on your system or in environments where downloading binaries is restricted, you can configure `node-jq` to use a local binary instead. Add the following to your `.npmrc` file:
-
-```bash
-# Use jq from system PATH
-jq-path=jq
-
-# Or specify an absolute path
-jq-path=/usr/local/bin/jq
-```
-
-Then install normally:
-
-```bash
-npm install node-jq --save
-```
-
-This approach is ideal for:
-- Corporate environments where web downloads are disallowed
-- Systems where `jq` is available through package managers
-- Build environments that need reproducible installations
-
-The configuration is automatically picked up from `.npmrc` and can be version-controlled with your project.
+- Ignore the installation by not running it with: `npm install node-jq --ignore-scripts`
+  ```bash
+  npm install node-jq --ignore-scripts
+  ```
+- Set `NODE_JQ_SKIP_INSTALL_BINARY` environment variable to `true`.
+  ```bash
+  export NODE_JQ_SKIP_INSTALL_BINARY="true"
+  npm install node-jq
+  ```
+- Set `JQ_PATH` environment variable
+  ```bash
+  export JQ_PATH="../../jq"
+  npm install node-jq
+  ```
+- Set `jq_path` in `.npmrc` (npm config files https://docs.npmjs.com/cli/v8/configuring-npm/npmrc)
+  ```t
+  # .npmrc
+  jq_path=/usr/local/bin/jq
+  ```
+  ```bash
+  npm install node-jq
+  ```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -281,8 +281,8 @@ Adds the `--argjson myfruit "{ 'hello': 'orange' }" --arg myfruit2 orange` argum
 ```javascript
 jq.run('{"fruit":$myfruit,"fruit2":$myfruit2}', ['/path/to/file.json'], { output: 'json', sort: true, args: { myfruit: { hello: 'orange' }, myfruit2: "banana" } }).then(console.log)
 // {
-//   fruit: { 
-//      hello: "orange" 
+//   fruit: {
+//      hello: "orange"
 //   },
 //   fruit2: "banana"
 // }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,11 +1,7 @@
 pre-push:
   parallel: true
-  commands:
-    test:
-      files: git diff --name-only HEAD @{push}
-      glob: "*.js"
+  jobs:
+    - name: test
       run: npm run test
-    lint:
-      files: git diff --name-only HEAD @{push}
-      glob: "*.js"
+    - name: lint
       run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
+        "lefthook": "^1.12.3",
         "mocha": "^10.0.0",
         "nyc": "^15.1.0",
         "prettier": "3.3.2",
@@ -6226,6 +6227,158 @@
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
       "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
       "dev": true
+    },
+    "node_modules/lefthook": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.12.3.tgz",
+      "integrity": "sha512-huMg+mGp6wHPjkaLdchuOvxVRMzvz6OVdhivatiH2Qn47O5Zm46jwzbVPYIanX6N/8ZTjGLBxv8tZ0KYmKt/Jg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "1.12.3",
+        "lefthook-darwin-x64": "1.12.3",
+        "lefthook-freebsd-arm64": "1.12.3",
+        "lefthook-freebsd-x64": "1.12.3",
+        "lefthook-linux-arm64": "1.12.3",
+        "lefthook-linux-x64": "1.12.3",
+        "lefthook-openbsd-arm64": "1.12.3",
+        "lefthook-openbsd-x64": "1.12.3",
+        "lefthook-windows-arm64": "1.12.3",
+        "lefthook-windows-x64": "1.12.3"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.12.3.tgz",
+      "integrity": "sha512-j1lwaosWRy3vhz8oQgCS1M6EUFN95aIYeNuqkczsBoAA6BDNAmVP1ctYEIYUK4bYaIgENbqbA9prYMAhyzh6Og==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.12.3.tgz",
+      "integrity": "sha512-x6aWFfLQX4m5zQ4X9zh5+hHOE5XTvNjz2zB9DI+xbIBLs2RRg0xJNT3OfgSrBU1QtEBneJ5dRQP5nl47td9GDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.12.3.tgz",
+      "integrity": "sha512-41OmulLqVZ0EOHmmHouJrpL59SwDD7FLoso4RsQVIBPaf8fHacdLo07Ye28VWQ5XolZQvnWcr1YXKo4JhqQMyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.12.3.tgz",
+      "integrity": "sha512-741/JRCJIS++hgYEH2uefN4FsH872V7gy2zDhcfQofiZnWP7+qhl4Wmwi8IpjIu4X7hLOC4cT18LOVU5L8KV9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.12.3.tgz",
+      "integrity": "sha512-BXIy1aDFZmFgmebJliNrEqZfX1lSOD4b/USvANv1UirFrNgTq5SRssd1CKfflT2PwKX6LsJTD4WabLLWZOxp9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.12.3.tgz",
+      "integrity": "sha512-FRdwdj5jsQAP2eVrtkVUqMqYNCbQ2Ix84izy29/BvLlu/hVypAGbDfUkgFnsmAd6ZsCBeYCEtPuqyg3E3SO0Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-openbsd-arm64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-1.12.3.tgz",
+      "integrity": "sha512-tch5wXY4GOjKAYohH7OFoxNdVHuUSYt2Pulo2VTkMYEG8IrvJnRO5MkvgHtKDHzU5mfABQYv5+ccJykDx5hQWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-openbsd-x64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-1.12.3.tgz",
+      "integrity": "sha512-IHbHg/rUFXrAN7LnjcQEtutCHBaD49CZge96Hpk0GZ2eEG5GTCNRnUyEf+Kf3+RTqHFgwtADdpeDa/ZaGZTM4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.12.3.tgz",
+      "integrity": "sha512-wghcE5TSpb+mbtemUV6uAo9hEK09kxRzhf2nPdeDX+fw42cL2TGZsbaCnDyzaY144C+L2/wEWrLIHJMnZYkuqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.12.3.tgz",
+      "integrity": "sha512-7Co/L8e2x2hGC1L33jDJ4ZlTkO3PJm25GOGpLfN1kqwhGB/uzMLeTI/PBczjlIN8isUv26ouNd9rVR7Bibrwyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -21226,6 +21379,94 @@
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
       "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
       "dev": true
+    },
+    "lefthook": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.12.3.tgz",
+      "integrity": "sha512-huMg+mGp6wHPjkaLdchuOvxVRMzvz6OVdhivatiH2Qn47O5Zm46jwzbVPYIanX6N/8ZTjGLBxv8tZ0KYmKt/Jg==",
+      "dev": true,
+      "requires": {
+        "lefthook-darwin-arm64": "1.12.3",
+        "lefthook-darwin-x64": "1.12.3",
+        "lefthook-freebsd-arm64": "1.12.3",
+        "lefthook-freebsd-x64": "1.12.3",
+        "lefthook-linux-arm64": "1.12.3",
+        "lefthook-linux-x64": "1.12.3",
+        "lefthook-openbsd-arm64": "1.12.3",
+        "lefthook-openbsd-x64": "1.12.3",
+        "lefthook-windows-arm64": "1.12.3",
+        "lefthook-windows-x64": "1.12.3"
+      }
+    },
+    "lefthook-darwin-arm64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.12.3.tgz",
+      "integrity": "sha512-j1lwaosWRy3vhz8oQgCS1M6EUFN95aIYeNuqkczsBoAA6BDNAmVP1ctYEIYUK4bYaIgENbqbA9prYMAhyzh6Og==",
+      "dev": true,
+      "optional": true
+    },
+    "lefthook-darwin-x64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.12.3.tgz",
+      "integrity": "sha512-x6aWFfLQX4m5zQ4X9zh5+hHOE5XTvNjz2zB9DI+xbIBLs2RRg0xJNT3OfgSrBU1QtEBneJ5dRQP5nl47td9GDQ==",
+      "dev": true,
+      "optional": true
+    },
+    "lefthook-freebsd-arm64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.12.3.tgz",
+      "integrity": "sha512-41OmulLqVZ0EOHmmHouJrpL59SwDD7FLoso4RsQVIBPaf8fHacdLo07Ye28VWQ5XolZQvnWcr1YXKo4JhqQMyw==",
+      "dev": true,
+      "optional": true
+    },
+    "lefthook-freebsd-x64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.12.3.tgz",
+      "integrity": "sha512-741/JRCJIS++hgYEH2uefN4FsH872V7gy2zDhcfQofiZnWP7+qhl4Wmwi8IpjIu4X7hLOC4cT18LOVU5L8KV9Q==",
+      "dev": true,
+      "optional": true
+    },
+    "lefthook-linux-arm64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.12.3.tgz",
+      "integrity": "sha512-BXIy1aDFZmFgmebJliNrEqZfX1lSOD4b/USvANv1UirFrNgTq5SRssd1CKfflT2PwKX6LsJTD4WabLLWZOxp9A==",
+      "dev": true,
+      "optional": true
+    },
+    "lefthook-linux-x64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.12.3.tgz",
+      "integrity": "sha512-FRdwdj5jsQAP2eVrtkVUqMqYNCbQ2Ix84izy29/BvLlu/hVypAGbDfUkgFnsmAd6ZsCBeYCEtPuqyg3E3SO0Rg==",
+      "dev": true,
+      "optional": true
+    },
+    "lefthook-openbsd-arm64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-1.12.3.tgz",
+      "integrity": "sha512-tch5wXY4GOjKAYohH7OFoxNdVHuUSYt2Pulo2VTkMYEG8IrvJnRO5MkvgHtKDHzU5mfABQYv5+ccJykDx5hQWA==",
+      "dev": true,
+      "optional": true
+    },
+    "lefthook-openbsd-x64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-1.12.3.tgz",
+      "integrity": "sha512-IHbHg/rUFXrAN7LnjcQEtutCHBaD49CZge96Hpk0GZ2eEG5GTCNRnUyEf+Kf3+RTqHFgwtADdpeDa/ZaGZTM4g==",
+      "dev": true,
+      "optional": true
+    },
+    "lefthook-windows-arm64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.12.3.tgz",
+      "integrity": "sha512-wghcE5TSpb+mbtemUV6uAo9hEK09kxRzhf2nPdeDX+fw42cL2TGZsbaCnDyzaY144C+L2/wEWrLIHJMnZYkuqA==",
+      "dev": true,
+      "optional": true
+    },
+    "lefthook-windows-x64": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.12.3.tgz",
+      "integrity": "sha512-7Co/L8e2x2hGC1L33jDJ4ZlTkO3PJm25GOGpLfN1kqwhGB/uzMLeTI/PBczjlIN8isUv26ouNd9rVR7Bibrwyg==",
+      "dev": true,
+      "optional": true
     },
     "levn": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "install-binary": "node scripts/install-binary.mjs",
     "test": "nyc mocha src/*.test.ts -r @swc-node/register",
     "test:watch": "npm test -- --watch",
-    "lint": "eslint ./src",
+    "lint": "eslint .",
     "build": "swc ./src --delete-dir-on-start -d lib --strip-leading-paths && tsc",
     "preinstall": "npm run install-binary",
     "coverage": "nyc report --reporter=lcov",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@arkweid/lefthook": "^0.7.7",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^12.0.0",
     "@semantic-release/github": "^9.0.4",
@@ -82,6 +81,7 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
+    "lefthook": "^1.12.3",
     "mocha": "^10.0.0",
     "nyc": "^15.1.0",
     "prettier": "3.3.2",

--- a/scripts/install-binary.mjs
+++ b/scripts/install-binary.mjs
@@ -5,19 +5,23 @@
 // First check if the user has configured the environment variable to skip the download of jq binary
 
 if (process.env.NODE_JQ_SKIP_INSTALL_BINARY === 'true') {
-  console.log('node-jq is skipping the download of jq binary');
-  process.exit(0);
+  console.log('node-jq is skipping the download of jq binary')
+  process.exit(0)
 }
 
 if (process.env.JQ_PATH) {
-  console.log('node-jq is skipping the download of jq binary');
-  console.log(`Using the configured jq binary by environment variable JQ_PATH at "${process.env.JQ_PATH}"`)
-  process.exit(0);
+  console.log('node-jq is skipping the download of jq binary')
+  console.log(
+    `Using the configured jq binary by environment variable JQ_PATH at "${process.env.JQ_PATH}"`,
+  )
+  process.exit(0)
 }
 
 if (process.env.npm_config_jq_path) {
   console.log('node-jq is skipping the download of jq binary')
-  console.log(`Using the configured jq binary by npm_config_jq_path at "${process.env.npm_config_jq_path}"`)
+  console.log(
+    `Using the configured jq binary by npm_config_jq_path at "${process.env.npm_config_jq_path}"`,
+  )
   process.exit(0)
 }
 

--- a/scripts/install-binary.mjs
+++ b/scripts/install-binary.mjs
@@ -2,9 +2,22 @@
 
 'use strict'
 
-// First check if the user has configured a local jq binary
+// First check if the user has configured the environment variable to skip the download of jq binary
+
+if (process.env.NODE_JQ_SKIP_INSTALL_BINARY === 'true') {
+  console.log('node-jq is skipping the download of jq binary');
+  process.exit(0);
+}
+
+if (process.env.JQ_PATH) {
+  console.log('node-jq is skipping the download of jq binary');
+  console.log(`Using the configured jq binary by environment variable JQ_PATH at "${process.env.JQ_PATH}"`)
+  process.exit(0);
+}
+
 if (process.env.npm_config_jq_path) {
-  console.log(`Using configured local jq binary: ${process.env.npm_config_jq_path}`)
+  console.log('node-jq is skipping the download of jq binary')
+  console.log(`Using the configured jq binary by npm_config_jq_path at "${process.env.npm_config_jq_path}"`)
   process.exit(0)
 }
 
@@ -56,11 +69,6 @@ if (!existsSync(OUTPUT_DIR)) {
 
 if (fileExist(join(OUTPUT_DIR, JQ_NAME))) {
   console.log('jq is already installed')
-  process.exit(0)
-}
-
-if (process.env.NODE_JQ_SKIP_INSTALL_BINARY === 'true') {
-  console.log('node-jq is skipping the download of jq binary')
   process.exit(0)
 }
 

--- a/scripts/install-binary.mjs
+++ b/scripts/install-binary.mjs
@@ -9,6 +9,12 @@ if (process.env.NODE_JQ_SKIP_INSTALL_BINARY === 'true') {
   process.exit(0);
 }
 
+if (process.env.JQ_PATH) {
+  console.log('node-jq is skipping the download of jq binary');
+  console.log(`Using the configured jq binary by environment variable JQ_PATH at "${process.env.JQ_PATH}"`)
+  process.exit(0);
+}
+
 if (process.env.npm_config_jq_path) {
   console.log('node-jq is skipping the download of jq binary')
   console.log(`Using the configured jq binary by npm_config_jq_path at "${process.env.npm_config_jq_path}"`)

--- a/scripts/install-binary.mjs
+++ b/scripts/install-binary.mjs
@@ -9,12 +9,6 @@ if (process.env.NODE_JQ_SKIP_INSTALL_BINARY === 'true') {
   process.exit(0);
 }
 
-if (process.env.JQ_PATH) {
-  console.log('node-jq is skipping the download of jq binary');
-  console.log(`Using the configured jq binary by environment variable JQ_PATH at "${process.env.JQ_PATH}"`)
-  process.exit(0);
-}
-
 if (process.env.npm_config_jq_path) {
   console.log('node-jq is skipping the download of jq binary')
   console.log(`Using the configured jq binary by npm_config_jq_path at "${process.env.npm_config_jq_path}"`)

--- a/src/command.ts
+++ b/src/command.ts
@@ -58,13 +58,11 @@ export const commandFactory = (
   filter: FilterInput,
   json: JsonInput,
   options?: OptionsInput,
-  jqPath?: string,
 ): Command => {
-  const command = jqPath ? path.join(jqPath, './jq') : JQ_PATH
   const { args, stdin } = validateArguments(filter, json, options ?? {})
 
   return {
-    command,
+    command: JQ_PATH,
     args,
     stdin,
   }

--- a/src/jq.test.ts
+++ b/src/jq.test.ts
@@ -194,4 +194,26 @@ describe('jq core', () => {
         done(error)
       })
   })
+
+  it('should output empty string for a match on json output', (done) => {
+    run('.foo', { foo: '' }, { input: 'json', output: 'json' })
+      .then((output) => {
+        expect(output).to.equal('')
+        done()
+      })
+      .catch((error) => {
+        done(error)
+      })
+  })
+
+  it('should output undefined for no match on json output', (done) => {
+    run('select(.foo == "bar")', { foo: '' }, { input: 'json', output: 'json' })
+      .then((output) => {
+        expect(output).to.equal(undefined)
+        done()
+      })
+      .catch((error) => {
+        done(error)
+      })
+  })
 })

--- a/src/jq.test.ts
+++ b/src/jq.test.ts
@@ -174,7 +174,7 @@ describe('jq core', () => {
   })
 
   it('should allow custom cwd', (done) => {
-    run(FILTER_VALID, PATH_JSON_FIXTURE, undefined, undefined, CWD_OPTION)
+    run(FILTER_VALID, PATH_JSON_FIXTURE, undefined, CWD_OPTION)
       .then((output) => {
         expect(output).to.equal('"git"')
         done()
@@ -185,7 +185,7 @@ describe('jq core', () => {
   })
 
   it('should run as detached', (done) => {
-    run(FILTER_VALID, PATH_JSON_FIXTURE, undefined, undefined, undefined, true)
+    run(FILTER_VALID, PATH_JSON_FIXTURE, undefined, undefined, true)
       .then((output) => {
         expect(output).to.equal('"git"')
         done()

--- a/src/jq.ts
+++ b/src/jq.ts
@@ -8,13 +8,16 @@ export const run = (
   options?: OptionsInput,
   cwd?: string,
   detached?: boolean,
-): Promise<object | string> => {
+): Promise<object | string | undefined> => {
   return new Promise((resolve, reject) => {
     const { command, args, stdin } = commandFactory(filter, json, options)
 
     exec(command, args, stdin, cwd, detached)
       .then((stdout) => {
         if (options?.output === 'json') {
+          if (stdout === '') {
+            return resolve(undefined)
+          }
           let result: object | string
           try {
             result = JSON.parse(stdout)

--- a/src/jq.ts
+++ b/src/jq.ts
@@ -6,17 +6,11 @@ export const run = (
   filter: FilterInput,
   json: JsonInput,
   options?: OptionsInput,
-  jqPath?: string,
   cwd?: string,
   detached?: boolean,
 ): Promise<object | string> => {
   return new Promise((resolve, reject) => {
-    const { command, args, stdin } = commandFactory(
-      filter,
-      json,
-      options,
-      jqPath,
-    )
+    const { command, args, stdin } = commandFactory(filter, json, options)
 
     exec(command, args, stdin, cwd, detached)
       .then((stdout) => {

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,5 +1,11 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["**/*", ".eslintrc.cjs", ".prettierrc.cjs"],
-  "exclude": ["node_modules"]
+  "include": [
+    "**/*",
+    ".eslintrc.cjs",
+    ".prettierrc.cjs"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
-  "extends": ["@tsconfig/strictest/tsconfig", "@tsconfig/node18/tsconfig"],
+  "extends": [
+    "@tsconfig/strictest/tsconfig",
+    "@tsconfig/node18/tsconfig"
+  ],
   "compilerOptions": {
     "declaration": true,
     "declarationDir": "lib",
@@ -7,6 +10,12 @@
     "noPropertyAccessFromIndexSignature": false,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.test.ts", "src/__test__"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.test.ts",
+    "src/__test__"
+  ]
 }


### PR DESCRIPTION
- BREAKING: If JQ_PATH is set, don't run the install binary script. Align behaviour from JQ_PATH with npm_config_jq_path https://github.com/sanack/node-jq/pull/724
- BREAKING: Remove jqPath from run
- BREAKING: Absorbs https://github.com/sanack/node-jq/pull/691 and fixes #689
- Run eslint in scripts
- Update lefthook to latest