### PR TITLE
fix: adds a proxy `jq` that calls the real local binary `_jq`

### DIFF
--- a/bin/jq
+++ b/bin/jq
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process')
+const path = require('path')
+
+const jqName = process.platform === 'win32' ? '_jq.exe' : '_jq'
+const jqPath = path.join(__dirname, jqName)
+
+const child = spawn(jqPath, process.argv.slice(2), { stdio: 'inherit' })
+child.on('exit', (code) => process.exit(code))

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "node-jq": "bin/jq"
       },
       "devDependencies": {
-        "@arkweid/lefthook": "^0.7.7",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/commit-analyzer": "^12.0.0",
         "@semantic-release/github": "^9.0.4",
@@ -69,26 +68,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@arkweid/lefthook": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@arkweid/lefthook/-/lefthook-0.7.7.tgz",
-      "integrity": "sha512-Eq30OXKmjxIAIsTtbX2fcF3SNZIXS8yry1u8yty7PQFYRctx04rVlhOJCEB2UmfTh8T2vrOMC9IHHUvvo5zbaQ==",
-      "cpu": [
-        "x64",
-        "arm64",
-        "ia32"
-      ],
-      "dev": true,
-      "hasInstallScript": true,
-      "os": [
-        "darwin",
-        "linux",
-        "win32"
-      ],
-      "bin": {
-        "lefthook": "bin/index.js"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -17101,12 +17080,6 @@
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"
       }
-    },
-    "@arkweid/lefthook": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@arkweid/lefthook/-/lefthook-0.7.7.tgz",
-      "integrity": "sha512-Eq30OXKmjxIAIsTtbX2fcF3SNZIXS8yry1u8yty7PQFYRctx04rVlhOJCEB2UmfTh8T2vrOMC9IHHUvvo5zbaQ==",
-      "dev": true
     },
     "@babel/code-frame": {
       "version": "7.24.7",

--- a/scripts/install-binary.mjs
+++ b/scripts/install-binary.mjs
@@ -49,8 +49,8 @@ const JQ_INFO = {
 }
 
 const JQ_NAME_MAP = {
-  def: 'jq',
-  win32: 'jq.exe',
+  def: '_jq',
+  win32: '_jq.exe',
 }
 const JQ_NAME =
   PLATFORM in JQ_NAME_MAP ? JQ_NAME_MAP[PLATFORM] : JQ_NAME_MAP.def

--- a/src/command.test.ts
+++ b/src/command.test.ts
@@ -9,8 +9,8 @@ const PATH_JSON_FIXTURE = path.join(PATH_FIXTURES, '1.json')
 const FILTER_VALID = '.repository.type'
 
 const EMPTY_OPTION_RESULT = {
-  command: path.join(__dirname, '../bin/jq'),
-  args: [FILTER_VALID, PATH_JSON_FIXTURE],
+  command: process.execPath, // use same node
+  args: [path.join(__dirname, '../bin/jq'), FILTER_VALID, PATH_JSON_FIXTURE],
   stdin: '',
 }
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -62,8 +62,8 @@ export const commandFactory = (
   const { args, stdin } = validateArguments(filter, json, options ?? {})
 
   return {
-    command: JQ_PATH,
-    args,
+    command: process.execPath,
+    args: [JQ_PATH, ...args],
     stdin,
   }
 }


### PR DESCRIPTION
Adds a node `jq` script that calls out to the locally-installed `_jq` binary. This prevents pnpm install from failing.
see: https://github.com/pnpm/pnpm/issues/1801

Fixes: #726