### PR TITLE
fix: align package-lock with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,9 @@
         "zod": "^3.23.8"
       },
       "bin": {
-        "node-jq": "bin/jq"
+        "node-jq": "bin/node-jq"
       },
       "devDependencies": {
-        "@arkweid/lefthook": "^0.7.7",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/commit-analyzer": "^12.0.0",
         "@semantic-release/github": "^9.0.4",
@@ -69,26 +68,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@arkweid/lefthook": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@arkweid/lefthook/-/lefthook-0.7.7.tgz",
-      "integrity": "sha512-Eq30OXKmjxIAIsTtbX2fcF3SNZIXS8yry1u8yty7PQFYRctx04rVlhOJCEB2UmfTh8T2vrOMC9IHHUvvo5zbaQ==",
-      "cpu": [
-        "x64",
-        "arm64",
-        "ia32"
-      ],
-      "dev": true,
-      "hasInstallScript": true,
-      "os": [
-        "darwin",
-        "linux",
-        "win32"
-      ],
-      "bin": {
-        "lefthook": "bin/index.js"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -17101,12 +17080,6 @@
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"
       }
-    },
-    "@arkweid/lefthook": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@arkweid/lefthook/-/lefthook-0.7.7.tgz",
-      "integrity": "sha512-Eq30OXKmjxIAIsTtbX2fcF3SNZIXS8yry1u8yty7PQFYRctx04rVlhOJCEB2UmfTh8T2vrOMC9IHHUvvo5zbaQ==",
-      "dev": true
     },
     "@babel/code-frame": {
       "version": "7.24.7",


### PR DESCRIPTION
[v6.1.1](https://github.com/sanack/node-jq/compare/v6.1.0...v6.1.1) introduced changes to the package.json that didn't get updated in the package-lock.json (specifically changes to the `bin` field in #727)

I think this is likely what's causing `npm publish` to fail to include the new `bin/node-jq` wrapper ([see the workflow run](https://github.com/sanack/node-jq/actions/runs/17332717438/job/49212301991#step:7:64)), but I don't have the permissions to do a dry-run of `semantic-release` to confirm.

Fixes: #726 
Fixes: #730 
(hopefully, finally 🤞)

### Notes
Out of scope for this fix but since the package.json specifies a minimum node version of `18`, it's probably a good idea to also specify the corresponding minimum `npm` version of `10`, which is the version shipped with Node 18 (this will only [trigger a warning](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#engines) if consumers for some reason are using an earlier version on npm along with node 18, so no need for a new major version). 

If this is done, it'd also be a good idea to delete and rebuild the package-lock.json again with npm v10, which will upgrade the [lockFileVersion](https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json#lockfileversion) from `2` to `3`, the default for npm v10. This mostly just removes redundant info that version 3 optimizes out.